### PR TITLE
Document product OTA release location

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ bring-up remain in the component repositories:
 - [Architecture and repository boundaries](docs/repositories.md)
 - [Contributing](CONTRIBUTING.md)
 
+## Releases
+
+Signed stable OTA bundles are published in the [LibreEcho Releases](https://github.com/aslater3/LibreEcho/releases)
+page. The release workflow remains owned by `LibreEcho-Kernel`, while this
+repository is the public product distribution point.
+
 ## Support
 
 Use the issue tracker for reproducible bugs and hardware problems. Include the

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -5,7 +5,7 @@ product-home repository.
 
 | Repository | Owns |
 | --- | --- |
-| `LibreEcho` | Product documentation, support, roadmap, cross-component issues, and release notes |
+| `LibreEcho` | Product documentation, support, roadmap, cross-component issues, release notes, and signed OTA release assets |
 | `LibreEcho-Kernel` | MT8163 kernel, initramfs, hardware bring-up, image construction, OTA verification, and release workflow |
 | `LibreEcho-UI` | Web control centre, HTTP API, service daemons, and UI tests |
 


### PR DESCRIPTION
Document that signed stable OTA bundles are distributed from this product repository, while the release workflow remains in LibreEcho-Kernel.