### PR TITLE
docs: update tooling repository name

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
-  - name: LibreEcho-Kernel implementation issues
-    url: https://github.com/aslater3/LibreEcho-Kernel/issues
+  - name: LibreEcho-Platform implementation issues
+    url: https://github.com/aslater3/LibreEcho-Platform/issues
     about: Use this for kernel, boot, Wi-Fi, image, or OTA implementation bugs.
   - name: LibreEcho-UI implementation issues
     url: https://github.com/aslater3/LibreEcho-UI/issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Where changes belong
 
 - Linux 6.1 kernel, device-tree, driver, and kernel-platform changes belong in [LibreEcho-Linux-6.1](https://github.com/aslater3/LibreEcho-Linux-6.1).
-- Initramfs, feature packaging, image construction, OTA, and ARM32 product-tooling changes belong in [LibreEcho-Kernel](https://github.com/aslater3/LibreEcho-Kernel).
+- Initramfs, feature packaging, image construction, OTA, and ARM32 product-tooling changes belong in [LibreEcho-Platform](https://github.com/aslater3/LibreEcho-Platform).
 - Web UI, API, and daemon changes belong in [LibreEcho-UI](https://github.com/aslater3/LibreEcho-UI).
 - Product documentation, installation guidance, and cross-component planning belong here.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### A repairable, private voice assistant for hardware you already own.
 
-[![Kernel checks](https://github.com/aslater3/LibreEcho-Kernel/actions/workflows/ota-release.yml/badge.svg?branch=main)](https://github.com/aslater3/LibreEcho-Kernel/actions/workflows/ota-release.yml)
+[![Platform checks](https://github.com/aslater3/LibreEcho-Platform/actions/workflows/ota-release.yml/badge.svg?branch=main)](https://github.com/aslater3/LibreEcho-Platform/actions/workflows/ota-release.yml)
 [![UI checks](https://github.com/aslater3/LibreEcho-UI/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/aslater3/LibreEcho-UI/actions/workflows/checks.yml)
 [![Latest OTA](https://img.shields.io/github/v/release/aslater3/LibreEcho?display_name=tag&label=latest%20OTA&logo=github)](https://github.com/aslater3/LibreEcho/releases/latest)
 [![Website](https://img.shields.io/badge/site-libreecho.org-16c7d9)](https://libreecho.org/)
@@ -32,7 +32,7 @@ release. Hardware fixes and service integration continue on review branches.
 - **Website:** [libreecho.org](https://libreecho.org/)
 - **Latest release:** [signed OTA bundles](https://github.com/aslater3/LibreEcho/releases/latest)
 - **Control centre:** [LibreEcho-UI](https://github.com/aslater3/LibreEcho-UI)
-- **Hardware and OS:** [LibreEcho-Kernel](https://github.com/aslater3/LibreEcho-Kernel)
+- **Hardware and OS:** [LibreEcho-Platform](https://github.com/aslater3/LibreEcho-Platform)
 - **Issues:** [report a reproducible product problem](https://github.com/aslater3/LibreEcho/issues/new/choose)
 - **Support:** [buy me a coffee](https://buymeacoffee.com/libreecho)
 
@@ -48,7 +48,7 @@ release. Hardware fixes and service integration continue on review branches.
 | Repository | Owns |
 | --- | --- |
 | [`LibreEcho`](https://github.com/aslater3/LibreEcho) | Product site, documentation, support, roadmap, issues, release notes, and OTA distribution |
-| [`LibreEcho-Kernel`](https://github.com/aslater3/LibreEcho-Kernel) | ARM32 product tooling, initramfs, feature packaging, OTA verification, and release workflow; the historical 3.18 tree remains here for compatibility |
+| [`LibreEcho-Platform`](https://github.com/aslater3/LibreEcho-Platform) | ARM32 product tooling, initramfs, feature packaging, OTA verification, and release workflow; the historical 3.18 tree remains here for compatibility |
 | [`LibreEcho-Linux-6.1`](https://github.com/aslater3/LibreEcho-Linux-6.1) | Current standalone MT8163 Linux 6.1 kernel line and kernel-side platform changes |
 | [`LibreEcho-UI`](https://github.com/aslater3/LibreEcho-UI) | Web control centre, HTTP API, service daemons, and UI tests |
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -6,7 +6,7 @@ product-home repository.
 | Repository | Owns |
 | --- | --- |
 | `LibreEcho` | Product documentation, support, roadmap, cross-component issues, release notes, and signed OTA release assets |
-| `LibreEcho-Kernel` | ARM32 product tooling, initramfs, feature packaging, OTA verification, and release workflow; historical 3.18 compatibility remains here |
+| `LibreEcho-Platform` | ARM32 product tooling, initramfs, feature packaging, OTA verification, and release workflow; historical 3.18 compatibility remains here |
 | `LibreEcho-Linux-6.1` | Current standalone MT8163 Linux 6.1 kernel line and kernel-side platform changes |
 | `LibreEcho-UI` | Web control centre, HTTP API, service daemons, and UI tests |
 

--- a/release/components.json
+++ b/release/components.json
@@ -48,7 +48,7 @@
       "name": "AirPlay, mDNS, D-Bus, crypto, and runtime closure",
       "license": "MIXED",
       "release_status": "blocked",
-      "source": "https://github.com/aslater3/LibreEcho-Kernel",
+      "source": "https://github.com/aslater3/LibreEcho-Platform",
       "required_evidence": ["exact-source-or-binary-provenance", "all-runtime-notices", "copyleft-source-offers", "dependency-sbom"]
     },
     {

--- a/tools/prepare-release.py
+++ b/tools/prepare-release.py
@@ -115,7 +115,7 @@ def main() -> None:
         "sources": {
             "product": source("https://github.com/aslater3/LibreEcho", args.product_commit),
             "kernel": source("https://github.com/aslater3/LibreEcho-Linux-6.1", args.kernel_commit),
-            "tooling": source("https://github.com/aslater3/LibreEcho-Kernel", args.tooling_commit),
+            "tooling": source("https://github.com/aslater3/LibreEcho-Platform", args.tooling_commit),
             "ui": source("https://github.com/aslater3/LibreEcho-UI", args.ui_commit),
         },
         "artifacts": records,


### PR DESCRIPTION
Update public repository labels and URLs from LibreEcho-Kernel to LibreEcho-Platform.

Also updates the release component source URL and sanitized provenance generator. Local checkout paths remain unchanged for build compatibility.