### PR TITLE
release: bind v0.1.0 source closure

### DIFF
--- a/release/COMMUNITY-NONCOMMERCIAL-SOURCE-CLOSURE.md
+++ b/release/COMMUNITY-NONCOMMERCIAL-SOURCE-CLOSURE.md
@@ -9,17 +9,17 @@ capture, wakeword-inference, or hardware-runtime acceptance.
 
 The source-offer hashes were derived from this immutable no-publish probe:
 
-- Run ID: `20260809T202654Z-19efd9685e22-clean-ota-production-community-nc-ssh0-ui50b9dedb9eed-44be97e50ff0`
+- Run ID: `20260811T214603Z-a6c4b01faae9-clean-ota-production-dev-community-nc-ssh0-ui021001d035c6-71f0be364c08`
 - Status: `PREPARED_NOT_FLASHED`
 - Published current: `false`
 - Feature policy: `community-noncommercial`
-- Linux source: `19efd9685e22f96cf1cb70551eae4c0075692e5c`
-- Platform source: `9eb5906d8104c20c6643d322c233cb87b6bd5673`
-- UI source: `50b9dedb9eedb21b0ea45b805421138a061db253`
-- Build source: `776ff299b483d3728a598c914025a585df6bf2ab`
-- Product policy source used by the probe: `cc0e1da04f9b117a0ff6b89081d1239b265dc241`
-- Boot SHA-256: `c65f67d7f40bc384ac1dc39274ea2875fd2b3141929f581c2488fb6934293aa3`
-- Source-offer index SHA-256: `b4f0d5188d3bfca9994bc14e87e4d4729cfa4923ca1d918ef413a9a1ce22cc19`
+- Linux source: `a6c4b01faae9b937f9067d4d14ee0917f662577c`
+- Platform source: `583cfbcc400767eb01187bf123abe6ad0dca824c`
+- UI source: `021001d035c6044b7f78841434ac3e58c48c5708`
+- Build source: `d2ff4c406c3948a2b52f089e1f972baa3399803c`
+- Product policy source used by the probe: `c0f3dc3ad89c3a739c0c477b3f98e26acc9a4d70`
+- Boot SHA-256: `c73a8cac2a981545b562ef3a4711f2f9622f3ec94432fbc21cedbf6ba3aee9b9`
+- Source-offer index SHA-256: `ed49a1bda6bb677fc2d39c4a1bba5c66ee9143193eea54a284ecb833d8b142e8`
 
 A final release candidate must be rebuilt after this catalog record is committed,
 attest that later Product commit, and reproduce the six archive hashes below.
@@ -32,24 +32,24 @@ verified for exact size and SHA-256. Each tar contains one additional generated
 
 | Component | Source-offer SHA-256 | Listed members verified |
 |---|---|---:|
-| Core runtime closure | `fcbcd29d4cf5fbe3b4c511c9a365bcd7adc7bf0eb6454d693fbcd5ddf31bc51f` | 117 |
-| AirPlay payload | `8678aba5db5359a988f9718552c18f9446763128215ec45e1596159031c9659e` | 438 |
-| STT payload | `5a494d737a3865675fba0ca1996aa062acf08e43fcdf9c149f2f364bef9396ce` | 1,169 |
-| TTS payload | `41fe96ec156379ddae46a6e6816de2673c12e5b4eb88b9b055d4573c148ba33e` | 1,169 |
-| Wakeword payload | `75d4e47bb784d9c21b41f351b16508c1b5a90ad837ee6fbf615c425e09158fc8` | 818 |
-| Assistant payload | `2b15821a7b44b02767f3f8c7029d3ba0637599644e2550aa39b273c075bc895d` | 561 |
+| Core runtime closure | `3e4f611fa07044c1e8e0060b7a1d9cc356493dfb42b963a82eccb9e9ff125952` | 93 |
+| AirPlay payload | `f159ecdb4e0381433c78c4e80a360bc6c3eb45e4c0c7f4caadbbe355c37a6031` | 393 |
+| STT payload | `e5ccaaed9380493bde952f5435ef6612d60b116c6c6e18bb6f00110d95742d03` | 1,131 |
+| TTS payload | `22be3e3cfc0446991a0a9c85c08c39d77212d44684322f6af1d9fa30761e9447` | 1,131 |
+| Wakeword payload | `8be7517a3f2feff5effe36f259ec2c35e3ffeded779fbfc4386f0c5bcb9833ac` | 58 |
+| Assistant payload | `85ee50f6befa873345b7444510c988e3625987fb4032170099d7c64f27541027` | 432 |
 
-Total sidecar-listed members independently verified: **4,272**.
+Total sidecar-listed members independently verified: **3,238**.
 
 ## Five feature payloads
 
 | Feature | Payload SHA-256 | Bytes |
 |---|---|---:|
-| AirPlay | `7f9e39a754cbed79f6e0520fc5f8df9695c890fb0bed364d4d593258604f4db7` | 8,036,352 |
-| STT | `5ff4e5c3a9d3da95b56f8d7c34f6efa0584993c41466de61084750fb7fcff554` | 57,663,488 |
-| TTS | `f086e8b1677e26ba984b2ecaf592e4f37bf04d24d99b3efb6a6eb25a53593a3c` | 150,216,704 |
-| Wakeword | `91445b330f5deaf0f1ce1bd1c34bc81d0dcb8b93b0aae25e4c1305dee80c90d6` | 8,192,000 |
-| Assistant | `117e7e3d454a63dd12b728d909619834a532b0b07c4b902b930cae71675c0154` | 2,973,696 |
+| AirPlay | `69457590a383c74bafa53183345ff56ecf68907e4fbc8a29c5a712926f5fc96f` | 7,995,392 |
+| STT | `969d05c576619a9a6ee986b9cba7dc95face689e4de8961a2a640e7f29e44fe1` | 57,659,392 |
+| TTS | `978994158b46b83213cf791db6dfb80b08e6e043c9d2ee4a9e73b106c15db128` | 150,216,704 |
+| Wakeword | `4140159883a47fb22286918298865a0364111b730f32160855f516e4ba126302` | 8,192,000 |
+| Assistant | `55e7ef2a927221b026e260cf5a1656a42bb13cf8d0725f8b56b9cdaee19a8f47` | 2,981,888 |
 
 The image and userdata manifests require all five payloads. The wakeword
 packager separately enforces the reviewed model identities:

--- a/release/components.json
+++ b/release/components.json
@@ -122,7 +122,7 @@
     {
       "id": "core-runtime-closure",
       "name": "Wireless tools, regulatory database, TinyALSA, libsodium, glibc, and GCC runtime closure",
-      "version": "source-offer-sha256:fcbcd29d4cf5fbe3b4c511c9a365bcd7adc7bf0eb6454d693fbcd5ddf31bc51f",
+      "version": "source-offer-sha256:3e4f611fa07044c1e8e0060b7a1d9cc356493dfb42b963a82eccb9e9ff125952",
       "license": "(GPL-2.0-only AND BSD-3-Clause AND ISC AND LGPL-2.1-or-later AND (GPL-3.0-or-later WITH GCC-exception-3.1))",
       "release_status": "cleared",
       "distribution_scope": "core-image",
@@ -148,7 +148,7 @@
     {
       "id": "airplay-payload",
       "name": "AirPlay 2, mDNS, D-Bus, crypto, FFmpeg, and runtime closure",
-      "version": "source-offer-sha256:8678aba5db5359a988f9718552c18f9446763128215ec45e1596159031c9659e",
+      "version": "source-offer-sha256:f159ecdb4e0381433c78c4e80a360bc6c3eb45e4c0c7f4caadbbe355c37a6031",
       "license": "(GPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-3-Clause AND MIT AND ISC AND Apache-2.0 AND OpenSSL)",
       "release_status": "cleared",
       "distribution_scope": "separate-payload",
@@ -174,7 +174,7 @@
     {
       "id": "stt-payload",
       "name": "Sherpa-ONNX streaming STT, ONNX Runtime, SpeexDSP, and model",
-      "version": "source-offer-sha256:5a494d737a3865675fba0ca1996aa062acf08e43fcdf9c149f2f364bef9396ce",
+      "version": "source-offer-sha256:e5ccaaed9380493bde952f5435ef6612d60b116c6c6e18bb6f00110d95742d03",
       "license": "(Apache-2.0 AND MIT AND BSD-3-Clause AND LGPL-2.1-or-later AND (GPL-3.0-or-later WITH GCC-exception-3.1))",
       "release_status": "cleared",
       "distribution_scope": "separate-payload",
@@ -200,7 +200,7 @@
     {
       "id": "tts-payload",
       "name": "Sherpa-ONNX TTS runtime, Piper voices, and eSpeak data",
-      "version": "source-offer-sha256:41fe96ec156379ddae46a6e6816de2673c12e5b4eb88b9b055d4573c148ba33e",
+      "version": "source-offer-sha256:22be3e3cfc0446991a0a9c85c08c39d77212d44684322f6af1d9fa30761e9447",
       "license": "(Apache-2.0 AND MIT AND GPL-3.0-or-later AND CC-BY-SA-4.0 AND LGPL-2.1-or-later AND (GPL-3.0-or-later WITH GCC-exception-3.1))",
       "release_status": "cleared",
       "distribution_scope": "separate-payload",
@@ -227,7 +227,7 @@
     {
       "id": "wakeword-payload",
       "name": "openWakeWord runtime and pretrained Alexa-compatible model",
-      "version": "source-offer-sha256:75d4e47bb784d9c21b41f351b16508c1b5a90ad837ee6fbf615c425e09158fc8",
+      "version": "source-offer-sha256:8be7517a3f2feff5effe36f259ec2c35e3ffeded779fbfc4386f0c5bcb9833ac",
       "license": "(MIT AND CC-BY-NC-SA-4.0 AND BSD-3-Clause)",
       "release_status": "cleared",
       "distribution_scope": "separate-payload",
@@ -256,7 +256,7 @@
     {
       "id": "assistant-payload",
       "name": "Assistant runtime, curl, and CA certificate closure",
-      "version": "source-offer-sha256:2b15821a7b44b02767f3f8c7029d3ba0637599644e2550aa39b273c075bc895d",
+      "version": "source-offer-sha256:85ee50f6befa873345b7444510c988e3625987fb4032170099d7c64f27541027",
       "license": "(MIT AND curl AND MPL-2.0)",
       "release_status": "cleared",
       "distribution_scope": "separate-payload",

--- a/release/radar-puffin-v0.1.0.md
+++ b/release/radar-puffin-v0.1.0.md
@@ -43,7 +43,8 @@ reuse.
 
 ## Source identities
 
-- Product: `c0f3dc3ad89c3a739c0c477b3f98e26acc9a4d70`
+- Final Product commit: see the sanitized release provenance asset generated
+  from the catalog-attesting release candidate.
 - Linux 6.1 kernel: `a6c4b01faae9b937f9067d4d14ee0917f662577c`
 - Platform/tooling: `583cfbcc400767eb01187bf123abe6ad0dca824c`
 - Web UI/services: `021001d035c6044b7f78841434ac3e58c48c5708`

--- a/release/radar-puffin-v0.1.0.md
+++ b/release/radar-puffin-v0.1.0.md
@@ -1,0 +1,59 @@
+# LibreEcho radar-puffin v0.1.0 community prerelease
+
+This is the first public **prerelease** of LibreEcho for the Amazon Echo 2nd Gen
+(`radar_puffin`, ARMv7, Linux 6.1). It is a development-channel,
+`community-noncommercial` artifact set for review and controlled installation.
+
+## Publication state
+
+- Build status: `PREPARED_NOT_FLASHED`
+- Exact boot, signed-OTA, payload, and source-offer identities are bound by the
+  release provenance and `radar-puffin-v0.1.0-SHA256SUMS` assets.
+
+No device was flashed, rebooted, slot-confirmed, or runtime-accepted as part of
+this publication. `PREPARED_NOT_FLASHED` is host-side release metadata, not a
+hardware deployment or compatibility claim.
+
+## Included artifacts
+
+- the verified ARM32 `boot.img` and locally signed OTA archive;
+- separate AirPlay, assistant, streaming STT, TTS, and wakeword SquashFS
+  payloads with manifests;
+- sanitized source provenance, SPDX 2.3 SBOM, notices, and checksums; and
+- six exact corresponding-source/relink offers plus sidecar manifests and a
+  source-offer index.
+
+The release excludes credentials, signing keys, device identifiers,
+calibration data, Amonet/vendor boot-chain material, and MT8163 connectivity
+firmware. Connectivity firmware remains an **owner-device-local** extraction
+input and is not redistributed.
+
+## License boundary
+
+LibreEcho-authored product code is MIT-licensed, but the complete artifact set
+contains separately licensed components. In particular, the wakeword model is
+licensed under **CC-BY-NC-SA-4.0**: use is **noncommercial**, attribution is
+required, and adapted material remains subject to **ShareAlike**. TTS voice
+assets include CC-BY-SA-4.0 material. Review `THIRD_PARTY_NOTICES.md`,
+`COMMUNITY-NONCOMMERCIAL-SOURCE-CLOSURE.md`, the SPDX SBOM, and embedded payload
+notices before redistribution or modification.
+
+Do not describe this community prerelease as permitting unrestricted commercial
+reuse.
+
+## Source identities
+
+- Product: `c0f3dc3ad89c3a739c0c477b3f98e26acc9a4d70`
+- Linux 6.1 kernel: `a6c4b01faae9b937f9067d4d14ee0917f662577c`
+- Platform/tooling: `583cfbcc400767eb01187bf123abe6ad0dca824c`
+- Web UI/services: `021001d035c6044b7f78841434ac3e58c48c5708`
+
+## Verification and installation caution
+
+Verify `radar-puffin-v0.1.0-SHA256SUMS` before use. The signed OTA contains
+exactly `boot.img`, `manifest`, and `manifest.sig`; its Ed25519 signature and
+host image contract were independently verified before publication.
+
+Do not flash a raw or renamed artifact outside the reviewed LibreEcho deployment
+flow. Preserve a confirmed rollback slot and owner data, and treat successful
+host verification as distinct from device runtime acceptance.

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -97,12 +97,12 @@ class ComponentGateTests(unittest.TestCase):
 
     def test_community_source_offer_hashes_match_catalog_and_closure(self) -> None:
         expected = {
-            "core-runtime-closure": "fcbcd29d4cf5fbe3b4c511c9a365bcd7adc7bf0eb6454d693fbcd5ddf31bc51f",
-            "airplay-payload": "8678aba5db5359a988f9718552c18f9446763128215ec45e1596159031c9659e",
-            "stt-payload": "5a494d737a3865675fba0ca1996aa062acf08e43fcdf9c149f2f364bef9396ce",
-            "tts-payload": "41fe96ec156379ddae46a6e6816de2673c12e5b4eb88b9b055d4573c148ba33e",
-            "wakeword-payload": "75d4e47bb784d9c21b41f351b16508c1b5a90ad837ee6fbf615c425e09158fc8",
-            "assistant-payload": "2b15821a7b44b02767f3f8c7029d3ba0637599644e2550aa39b273c075bc895d",
+            "core-runtime-closure": "3e4f611fa07044c1e8e0060b7a1d9cc356493dfb42b963a82eccb9e9ff125952",
+            "airplay-payload": "f159ecdb4e0381433c78c4e80a360bc6c3eb45e4c0c7f4caadbbe355c37a6031",
+            "stt-payload": "e5ccaaed9380493bde952f5435ef6612d60b116c6c6e18bb6f00110d95742d03",
+            "tts-payload": "22be3e3cfc0446991a0a9c85c08c39d77212d44684322f6af1d9fa30761e9447",
+            "wakeword-payload": "8be7517a3f2feff5effe36f259ec2c35e3ffeded779fbfc4386f0c5bcb9833ac",
+            "assistant-payload": "85ee50f6befa873345b7444510c988e3625987fb4032170099d7c64f27541027",
         }
         data = json.loads((ROOT / "release/components.json").read_text())
         closure = (
@@ -119,6 +119,15 @@ class ComponentGateTests(unittest.TestCase):
                     "release/COMMUNITY-NONCOMMERCIAL-SOURCE-CLOSURE.md",
                     by_id[component_id]["evidence"],
                 )
+
+    def test_v010_release_notes_state_and_legal_boundary(self) -> None:
+        notes = (ROOT / "release/radar-puffin-v0.1.0.md").read_text()
+        for required in (
+            "PREPARED_NOT_FLASHED", "prerelease", "CC-BY-NC-SA-4.0",
+            "noncommercial", "ShareAlike",
+            "No device was flashed", "owner-device-local",
+        ):
+            self.assertIn(required, notes)
 
     def test_documented_good_faith_fpga_record_is_accepted(self) -> None:
         data = json.loads((ROOT / "release/components.json").read_text())

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -128,6 +128,15 @@ class ComponentGateTests(unittest.TestCase):
             "No device was flashed", "owner-device-local",
         ):
             self.assertIn(required, notes)
+        normalized_notes = " ".join(notes.split())
+        self.assertIn(
+            "Final Product commit: see the sanitized release provenance asset",
+            normalized_notes,
+        )
+        self.assertNotIn(
+            "Product: `c0f3dc3ad89c3a739c0c477b3f98e26acc9a4d70`",
+            notes,
+        )
 
     def test_documented_good_faith_fpga_record_is_accepted(self) -> None:
         data = json.loads((ROOT / "release/components.json").read_text())


### PR DESCRIPTION
## Summary
- bind the v0.1.0 community prerelease catalog to the exact independently verified portable source offers
- record the no-publish probe identities, 3,238-member closure, payload identities, and noncommercial boundary
- add hash-independent prerelease notes; final boot/OTA hashes follow only after the catalog-attesting rebuild

## Verification
- `python3 tools/check-public-metadata.py`
- `python3 tools/check-release-components.py --release-scope commercially-unrestricted`
- `python3 tools/check-release-components.py --release-scope community-noncommercial`
- `python3 -m unittest tools.test_release_tools`
- `python3 -m py_compile tools/*.py`
- `git diff --check`

No publication, signing, hardware access, or deployment.
