### PR TITLE
fix(release): reject private run IDs in public metadata

### DIFF
--- a/release/COMMUNITY-NONCOMMERCIAL-SOURCE-CLOSURE.md
+++ b/release/COMMUNITY-NONCOMMERCIAL-SOURCE-CLOSURE.md
@@ -5,21 +5,12 @@ identities for LibreEcho's five-feature `community-noncommercial` profile. It is
 host-build evidence, not publication, legal advice, flashing, boot, playback,
 capture, wakeword-inference, or hardware-runtime acceptance.
 
-## Hash-derivation probe
+## Hash-derivation evidence
 
-The source-offer hashes were derived from this immutable no-publish probe:
-
-- Run ID: `20260811T214603Z-a6c4b01faae9-clean-ota-production-dev-community-nc-ssh0-ui021001d035c6-71f0be364c08`
-- Status: `PREPARED_NOT_FLASHED`
-- Published current: `false`
-- Feature policy: `community-noncommercial`
-- Linux source: `a6c4b01faae9b937f9067d4d14ee0917f662577c`
-- Platform source: `583cfbcc400767eb01187bf123abe6ad0dca824c`
-- UI source: `021001d035c6044b7f78841434ac3e58c48c5708`
-- Build source: `d2ff4c406c3948a2b52f089e1f972baa3399803c`
-- Product policy source used by the probe: `c0f3dc3ad89c3a739c0c477b3f98e26acc9a4d70`
-- Boot SHA-256: `c73a8cac2a981545b562ef3a4711f2f9622f3ec94432fbc21cedbf6ba3aee9b9`
-- Source-offer index SHA-256: `ed49a1bda6bb677fc2d39c4a1bba5c66ee9143193eea54a284ecb833d8b142e8`
+The source-offer hashes were derived from an immutable no-publish probe. The
+probe status and exact source/artifact hashes are retained in private build
+evidence; this public record contains only sanitized repository and artifact
+identities.
 
 A final release candidate must be rebuilt after this catalog record is committed,
 attest that later Product commit, and reproduce the six archive hashes below.

--- a/release/PUBLIC-AUDIO-SOURCE-CLOSURE.md
+++ b/release/PUBLIC-AUDIO-SOURCE-CLOSURE.md
@@ -6,7 +6,7 @@ capture, FPGA-runtime, or device-runtime claim.
 
 ## Candidate identity
 
-- Run ID: `20260809T155059Z-19efd9685e22-clean-ota-production-redistrib-ssh0-ui50b9dedb9eed-44be97e50ff0`
+This record is bound to the sanitized source and artifact identities below.
 - Linux source: `19efd9685e22f96cf1cb70551eae4c0075692e5c`
 - Platform source: `304806a69bc9df87b12e95e98252a011b26934d8`
 - UI source: `50b9dedb9eedb21b0ea45b805421138a061db253`

--- a/release/README.md
+++ b/release/README.md
@@ -97,7 +97,8 @@ The command fails closed when the candidate is dirty, contains embedded vendor
 files, identifies a device, or includes a component that is not cleared.
 Artifact paths are used only to calculate hashes and are never written to the
 output. Rename private run-generated artifacts to stable public-safe filenames
-before invoking the generator; run IDs are rejected in public artifact names.
+before invoking the generator; run IDs are rejected in public artifact names and
+release metadata.
 
 Do not use a generated per-run `manifest.json` as a public release manifest.
 It contains host paths and operational fields by design.

--- a/tools/check-public-metadata.py
+++ b/tools/check-public-metadata.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 IPV4 = re.compile(r"(?<![0-9.])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9.])")
 MAC = re.compile(r"(?<![0-9A-Fa-f])(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}(?![0-9A-Fa-f])")
+RUN_ID = re.compile(r"(?<![0-9A-Za-z])20[0-9]{6}T[0-9]{6}Z-[0-9A-Za-z][0-9A-Za-z-]*(?![0-9A-Za-z])")
 PRIVATE_NETWORKS = tuple(
     ipaddress.ip_network(value) for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 )
@@ -28,6 +29,8 @@ def violations(root: Path) -> list[str]:
         for marker in ("/home/", "/dev/tty"):
             if marker in text:
                 failures.append(f"{relative}: private marker {marker!r}")
+        for match in RUN_ID.finditer(text):
+            failures.append(f"{relative}: private run ID {match.group(0)}")
         for match in MAC.finditer(text):
             failures.append(f"{relative}: MAC address {match.group(0)}")
         for match in IPV4.finditer(text):

--- a/tools/check-public-metadata.py
+++ b/tools/check-public-metadata.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 IPV4 = re.compile(r"(?<![0-9.])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9.])")
 MAC = re.compile(r"(?<![0-9A-Fa-f])(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}(?![0-9A-Fa-f])")
-RUN_ID = re.compile(r"(?<![0-9A-Za-z])20[0-9]{6}T[0-9]{6}Z(?:[-_]|$)")
+RUN_ID = re.compile(r"(?<![0-9A-Za-z])20[0-9]{6}T[0-9]{6}Z(?![0-9A-Za-z])")
 PRIVATE_NETWORKS = tuple(
     ipaddress.ip_network(value) for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 )

--- a/tools/check-public-metadata.py
+++ b/tools/check-public-metadata.py
@@ -21,11 +21,13 @@ def violations(root: Path) -> list[str]:
     for path in sorted(root.rglob("*")):
         if not path.is_file():
             continue
+        relative = path.relative_to(root)
+        for match in RUN_ID.finditer(str(relative)):
+            failures.append(f"{relative}: private run ID {match.group(0)}")
         try:
             text = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        relative = path.relative_to(root)
         for marker in ("/home/", "/dev/tty"):
             if marker in text:
                 failures.append(f"{relative}: private marker {marker!r}")

--- a/tools/check-public-metadata.py
+++ b/tools/check-public-metadata.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 IPV4 = re.compile(r"(?<![0-9.])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9.])")
 MAC = re.compile(r"(?<![0-9A-Fa-f])(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}(?![0-9A-Fa-f])")
-RUN_ID = re.compile(r"(?<![0-9A-Za-z])20[0-9]{6}T[0-9]{6}Z(?:[-_][0-9A-Za-z][0-9A-Za-z_-]*)?(?![0-9A-Za-z_-])")
+RUN_ID = re.compile(r"(?<![0-9A-Za-z])20[0-9]{6}T[0-9]{6}Z(?:[-_]|$)")
 PRIVATE_NETWORKS = tuple(
     ipaddress.ip_network(value) for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 )

--- a/tools/check-public-metadata.py
+++ b/tools/check-public-metadata.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 IPV4 = re.compile(r"(?<![0-9.])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9.])")
 MAC = re.compile(r"(?<![0-9A-Fa-f])(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}(?![0-9A-Fa-f])")
-RUN_ID = re.compile(r"(?<![0-9A-Za-z])20[0-9]{6}T[0-9]{6}Z-[0-9A-Za-z][0-9A-Za-z-]*(?![0-9A-Za-z])")
+RUN_ID = re.compile(r"(?<![0-9A-Za-z])20[0-9]{6}T[0-9]{6}Z(?:[-_][0-9A-Za-z][0-9A-Za-z_-]*)?(?![0-9A-Za-z_-])")
 PRIVATE_NETWORKS = tuple(
     ipaddress.ip_network(value) for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 )

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -63,10 +63,18 @@ class PublicMetadataTests(unittest.TestCase):
     def test_run_ids_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
-            run_id = "20260811T214603Z-a6c4b01faae9-clean-ota"
-            (root / f"{run_id}.json").write_text("sanitized")
+            for run_id in (
+                "20260811T214603Z-a6c4b01faae9-clean-ota",
+                "20260811T214603Z_clean-ota",
+            ):
+                (root / f"{run_id}.json").write_text("sanitized")
             failures = PUBLIC_METADATA.violations(root)
-            self.assertTrue(any(f"{run_id}.json" in item for item in failures))
+            for run_id in (
+                "20260811T214603Z-a6c4b01faae9-clean-ota",
+                "20260811T214603Z_clean-ota",
+            ):
+                with self.subTest(run_id=run_id):
+                    self.assertTrue(any(f"{run_id}.json" in item for item in failures))
 
 
 class ComponentGateTests(unittest.TestCase):

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -60,6 +60,15 @@ class PublicMetadataTests(unittest.TestCase):
             self.assertTrue(any("private IPv4" in item for item in failures))
             self.assertTrue(any("MAC address" in item for item in failures))
 
+    def test_run_ids_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "run.md").write_text(
+                "internal candidate 20260811T214603Z-a6c4b01faae9-clean-ota"
+            )
+            failures = PUBLIC_METADATA.violations(root)
+            self.assertTrue(any("private run ID" in item for item in failures))
+
 
 class ComponentGateTests(unittest.TestCase):
     def test_public_catalog_scopes_noncommercial_wakeword(self) -> None:

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -63,11 +63,10 @@ class PublicMetadataTests(unittest.TestCase):
     def test_run_ids_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
-            (root / "run.md").write_text(
-                "internal candidate 20260811T214603Z-a6c4b01faae9-clean-ota"
-            )
+            run_id = "20260811T214603Z-a6c4b01faae9-clean-ota"
+            (root / f"{run_id}.json").write_text("sanitized")
             failures = PUBLIC_METADATA.violations(root)
-            self.assertTrue(any("private run ID" in item for item in failures))
+            self.assertTrue(any(f"{run_id}.json" in item for item in failures))
 
 
 class ComponentGateTests(unittest.TestCase):

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -68,17 +68,23 @@ class PublicMetadataTests(unittest.TestCase):
                 "20260811T214603Z_clean-ota",
                 "20260811T214603Z-",
                 "20260811T214603Z_",
+                "20260811T214603Z",
             ):
                 (root / f"{run_id}.json").write_text("sanitized")
+            nested = root / "20260811T214603Z" / "metadata.json"
+            nested.parent.mkdir()
+            nested.write_text("sanitized")
             failures = PUBLIC_METADATA.violations(root)
             for run_id in (
                 "20260811T214603Z-a6c4b01faae9-clean-ota",
                 "20260811T214603Z_clean-ota",
                 "20260811T214603Z-",
                 "20260811T214603Z_",
+                "20260811T214603Z",
             ):
                 with self.subTest(run_id=run_id):
                     self.assertTrue(any(f"{run_id}.json" in item for item in failures))
+            self.assertTrue(any("20260811T214603Z/metadata.json" in item for item in failures))
 
 
 class ComponentGateTests(unittest.TestCase):

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -66,12 +66,16 @@ class PublicMetadataTests(unittest.TestCase):
             for run_id in (
                 "20260811T214603Z-a6c4b01faae9-clean-ota",
                 "20260811T214603Z_clean-ota",
+                "20260811T214603Z-",
+                "20260811T214603Z_",
             ):
                 (root / f"{run_id}.json").write_text("sanitized")
             failures = PUBLIC_METADATA.violations(root)
             for run_id in (
                 "20260811T214603Z-a6c4b01faae9-clean-ota",
                 "20260811T214603Z_clean-ota",
+                "20260811T214603Z-",
+                "20260811T214603Z_",
             ):
                 with self.subTest(run_id=run_id):
                     self.assertTrue(any(f"{run_id}.json" in item for item in failures))


### PR DESCRIPTION
## Summary
- remove internal build-run identifiers from public closure records
- reject timestamped private run IDs in the public metadata gate
- add regression coverage while preserving existing path/IP/MAC checks

## Validation
- 20 explicit release-tool tests pass
- public metadata gate passes
- unrestricted and community-noncommercial component gates pass
- Python compilation, JSON parsing, and git diff --check pass

No release, signing, flashing, reboot, or hardware action is included.