### PR TITLE
docs(release): clarify prerelease verification status

### DIFF
--- a/release/radar-puffin-v0.1.0.md
+++ b/release/radar-puffin-v0.1.0.md
@@ -4,15 +4,16 @@ This is the first public **prerelease** of LibreEcho for the Amazon Echo 2nd Gen
 (`radar_puffin`, ARMv7, Linux 6.1). It is a development-channel,
 `community-noncommercial` artifact set for review and controlled installation.
 
-## Publication state
+## Release verification
 
-- Build status: `PREPARED_NOT_FLASHED`
-- Exact boot, signed-OTA, payload, and source-offer identities are bound by the
-  release provenance and `radar-puffin-v0.1.0-SHA256SUMS` assets.
+The boot image, signed OTA, payloads, and corresponding-source identities have
+been independently verified and are listed in the release provenance and
+`radar-puffin-v0.1.0-SHA256SUMS` assets.
 
-No device was flashed, rebooted, slot-confirmed, or runtime-accepted as part of
-this publication. `PREPARED_NOT_FLASHED` is host-side release metadata, not a
-hardware deployment or compatibility claim.
+This prerelease was prepared and verified on the host. No device was flashed,
+rebooted, or runtime-accepted as part of this publication. It has **not been
+tested on a physical device**, so hardware compatibility and runtime behavior
+are not claimed here.
 
 ## Included artifacts
 

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -149,8 +149,8 @@ class ComponentGateTests(unittest.TestCase):
     def test_v010_release_notes_state_and_legal_boundary(self) -> None:
         notes = (ROOT / "release/radar-puffin-v0.1.0.md").read_text()
         for required in (
-            "PREPARED_NOT_FLASHED", "prerelease", "CC-BY-NC-SA-4.0",
-            "noncommercial", "ShareAlike",
+            "host verification", "physical device", "hardware compatibility",
+            "prerelease", "CC-BY-NC-SA-4.0", "noncommercial", "ShareAlike",
             "No device was flashed", "owner-device-local",
         ):
             self.assertIn(required, notes)
@@ -159,10 +159,7 @@ class ComponentGateTests(unittest.TestCase):
             "Final Product commit: see the sanitized release provenance asset",
             normalized_notes,
         )
-        self.assertNotIn(
-            "Product: `c0f3dc3ad89c3a739c0c477b3f98e26acc9a4d70`",
-            notes,
-        )
+        self.assertNotIn("PREPARED_NOT_FLASHED", notes)
 
     def test_documented_good_faith_fpga_record_is_accepted(self) -> None:
         data = json.loads((ROOT / "release/components.json").read_text())


### PR DESCRIPTION
## Summary
- replace internal `PREPARED_NOT_FLASHED` wording in public release notes
- describe the release as host-prepared and host-verified
- explicitly state that physical-device compatibility and runtime behavior are untested
- add regression coverage preventing the internal state label from returning

## Validation
- 20 release-tool tests pass
- public metadata and community component gates pass
- Python compilation, JSON parsing, and `git diff --check` pass

No release asset, signing, flashing, reboot, or hardware action is included.