### PR TITLE
ci: publish release when Product PR merges

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
     paths:
       - 'release/*-candidate.json'
-      - 'release/*.md'
-      - 'CHANGELOG.md'
 
 permissions:
   actions: read
@@ -27,7 +25,9 @@ jobs:
           BUILD_TOKEN: ${{ secrets.LIBREECHO_BUILD_READ_TOKEN }}
         run: |
           set -euo pipefail
-          candidate="$(git ls-tree -r --name-only HEAD release | grep -- '-candidate\.json$' | sort | tail -1)"
+          mapfile -t changed < <(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA" -- 'release/*-candidate.json')
+          test "${#changed[@]}" -eq 1
+          candidate="${changed[0]}"
           test -n "$candidate"
           python3 - "$candidate" >>"$GITHUB_OUTPUT" <<'PY'
           import json, sys
@@ -50,19 +50,22 @@ jobs:
           VERSION: ${{ steps.candidate.outputs.version }}
         run: |
           set -euo pipefail
-          test -f "public-release/public-release/${VERSION}-SHA256SUMS" || test -f "public-release/${VERSION}-SHA256SUMS"
+          test -f "public-release/public-release/libreecho-${VERSION}-SHA256SUMS" || test -f "public-release/libreecho-${VERSION}-SHA256SUMS"
           dir=public-release/public-release
           test -d "$dir" || dir=public-release
           mapfile -t assets < <(find "$dir" -maxdepth 1 -type f -printf '%f\n' | sort)
-          test "${#assets[@]}" -gt 0
-          printf '%s\n' "${assets[@]}" | grep -q -- '-SHA256SUMS$'
+          test "${#assets[@]}" -ge 3
+          printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-boot.img"
+          printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-initial-install.tar"
+          printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-SHA256SUMS"
+          (cd "$dir" && sha256sum -c "libreecho-${VERSION}-SHA256SUMS")
           if printf '%s\n' "${assets[@]}" | grep -Eiq 'source-offer|provenance|\.spdx\.json|source-closure'; then
             echo 'unexpected compliance asset in public release' >&2; exit 1
           fi
           tag="$VERSION"
           release_id="$(gh release view "$tag" --json databaseId --jq .databaseId 2>/dev/null || true)"
           if [ -z "$release_id" ]; then
-            gh release create "$tag" --title "LibreEcho $VERSION" --notes-file "release/${VERSION}.md" --prerelease
+            gh release create "$tag" --target "$GITHUB_SHA" --title "LibreEcho $VERSION" --notes-file "release/${VERSION}.md" --prerelease
             release_id="$(gh release view "$tag" --json databaseId --jq .databaseId)"
           fi
           gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" --jq '.assets[].id' |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,76 @@
+name: Publish merged release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'release/*-candidate.json'
+      - 'release/*.md'
+      - 'CHANGELOG.md'
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    environment: public-release
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Read merged candidate
+        id: candidate
+        env:
+          BUILD_TOKEN: ${{ secrets.LIBREECHO_BUILD_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          candidate="$(git ls-tree -r --name-only HEAD release | grep -- '-candidate\.json$' | sort | tail -1)"
+          test -n "$candidate"
+          python3 - "$candidate" >>"$GITHUB_OUTPUT" <<'PY'
+          import json, sys
+          data=json.load(open(sys.argv[1], encoding='utf-8'))
+          for key in ('version','source_run_id','source_run_attempt'):
+              if key not in data: raise SystemExit(f'missing candidate field: {key}')
+              print(f'{key}={data[key]}')
+          PY
+      - name: Download exact Build staging artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          repository: aslater3/LibreEcho-Build
+          run-id: ${{ steps.candidate.outputs.source_run_id }}
+          github-token: ${{ secrets.LIBREECHO_BUILD_READ_TOKEN }}
+          name: community-noncommercial-candidate-${{ steps.candidate.outputs.source_run_id }}-${{ steps.candidate.outputs.source_run_attempt }}
+          path: public-release
+      - name: Publish bounded assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.candidate.outputs.version }}
+        run: |
+          set -euo pipefail
+          test -f "public-release/public-release/${VERSION}-SHA256SUMS" || test -f "public-release/${VERSION}-SHA256SUMS"
+          dir=public-release/public-release
+          test -d "$dir" || dir=public-release
+          mapfile -t assets < <(find "$dir" -maxdepth 1 -type f -printf '%f\n' | sort)
+          test "${#assets[@]}" -gt 0
+          printf '%s\n' "${assets[@]}" | grep -q -- '-SHA256SUMS$'
+          if printf '%s\n' "${assets[@]}" | grep -Eiq 'source-offer|provenance|\.spdx\.json|source-closure'; then
+            echo 'unexpected compliance asset in public release' >&2; exit 1
+          fi
+          tag="$VERSION"
+          release_id="$(gh release view "$tag" --json databaseId --jq .databaseId 2>/dev/null || true)"
+          if [ -z "$release_id" ]; then
+            gh release create "$tag" --title "LibreEcho $VERSION" --notes-file "release/${VERSION}.md" --prerelease
+            release_id="$(gh release view "$tag" --json databaseId --jq .databaseId)"
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" --jq '.assets[].id' |
+            while read -r id; do gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${id}" >/dev/null; done
+          for asset in "${assets[@]}"; do
+            gh release upload "$tag" "$dir/$asset" --clobber
+          done
+          actual="$(gh release view "$tag" --json assets --jq '.assets | map(.name) | sort | join("\n")')"
+          expected="$(printf '%s\n' "${assets[@]}" | sort)"
+          test "$actual" = "$expected"
+          echo "release_publish=PASS assets=${#assets[@]} tag=$tag"

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -9,6 +9,7 @@ on:
       - 'tools/check-release-components.py'
       - 'tools/test_release_tools.py'
       - '.github/workflows/release-gate.yml'
+      - '.github/workflows/publish-release.yml'
   push:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - 'tools/check-release-components.py'
       - 'tools/test_release_tools.py'
       - '.github/workflows/release-gate.yml'
+      - '.github/workflows/publish-release.yml'
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Release entries are added by the Build release candidate PR workflow.


### PR DESCRIPTION
Add the Product main merge publisher. It reads the merged candidate record, downloads the exact Build artifact, rejects compliance/source-offer assets, replaces the target release assets, and verifies the final inventory.