### PR TITLE
fix: publish OTA channel alias

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,7 +35,9 @@ jobs:
           for key in ('version','source_run_id','source_run_attempt'):
               if key not in data: raise SystemExit(f'missing candidate field: {key}')
               print(f'{key}={data[key]}')
-          print(f"channel={data.get('channel','stable')}")
+          channel=data.get('channel','stable')
+          if channel not in ('stable','dev'): raise SystemExit('invalid candidate channel')
+          print(f'channel={channel}')
           PY
       - name: Download exact Build staging artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -54,8 +56,9 @@ jobs:
           test -f "public-release/public-release/libreecho-${VERSION}-SHA256SUMS" || test -f "public-release/libreecho-${VERSION}-SHA256SUMS"
           dir=public-release/public-release
           test -d "$dir" || dir=public-release
-          mapfile -t assets < <(find "$dir" -maxdepth 1 -type f -printf '%f\n' ! -name '.assets' | sort)
+          mapfile -t assets < <(find "$dir" -maxdepth 1 -type f ! -name '.assets' -printf '%f\n' | sort)
           test "${#assets[@]}" -ge 3
+          test -f "$dir/libreecho-${VERSION}.ota.tar"
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-boot.img"
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-initial-install.tar"
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-SHA256SUMS"
@@ -77,7 +80,7 @@ jobs:
           printf '%s\n' "${assets[@]}" | sort -u >"$dir/.assets"
           mapfile -t assets <"$dir/.assets"
           (cd "$dir" && find . -maxdepth 1 -type f ! -name '*-SHA256SUMS' ! -name '.assets' -printf '%f\0' | sort -z | xargs -0 sha256sum >"libreecho-${VERSION}-SHA256SUMS")
-          mapfile -t assets < <(find "$dir" -maxdepth 1 -type f -printf '%f\n' ! -name '.assets' | sort)
+          mapfile -t assets < <(find "$dir" -maxdepth 1 -type f ! -name '.assets' -printf '%f\n' | sort)
           tag="$VERSION"
           release_id="$(gh release view "$tag" --json databaseId --jq .databaseId 2>/dev/null || true)"
           if [ -z "$release_id" ]; then

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,30 +51,34 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.candidate.outputs.version }}
+          CANDIDATE_CHANNEL: ${{ steps.candidate.outputs.channel }}
         run: |
           set -euo pipefail
-          test -f "public-release/public-release/libreecho-${VERSION}-SHA256SUMS" || test -f "public-release/libreecho-${VERSION}-SHA256SUMS"
+          case "$CANDIDATE_CHANNEL" in
+            stable|dev) ;;
+            *) echo "invalid candidate channel: $CANDIDATE_CHANNEL" >&2; exit 1 ;;
+          esac
           dir=public-release/public-release
           test -d "$dir" || dir=public-release
+          sums="libreecho-${VERSION}-SHA256SUMS"
+          test -f "$dir/$sums"
+          ota="libreecho-${VERSION}.ota.tar"
+          test -f "$dir/$ota"
           mapfile -t assets < <(find "$dir" -maxdepth 1 -type f ! -name '.assets' -printf '%f\n' | sort)
-          test "${#assets[@]}" -ge 3
-          test -f "$dir/libreecho-${VERSION}.ota.tar"
+          test "${#assets[@]}" -ge 4
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-boot.img"
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-initial-install.tar"
-          printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-SHA256SUMS"
-          (cd "$dir" && sha256sum -c "libreecho-${VERSION}-SHA256SUMS")
+          printf '%s\n' "${assets[@]}" | grep -qx "$sums"
+          printf '%s\n' "${assets[@]}" | grep -qx "$ota"
+          grep -Fqx "  $ota" "$dir/$sums"
+          (cd "$dir" && sha256sum -c "$sums")
           if printf '%s\n' "${assets[@]}" | grep -Eiq 'source-offer|provenance|\.spdx\.json|source-closure'; then
             echo 'unexpected compliance asset in public release' >&2; exit 1
           fi
-          assets=("${assets[@]}")
-          assets=("${assets[@]}")
           for alias in stable dev; do
-            asset="libreecho-${VERSION}.ota.tar"
-            if [ -f "$dir/$asset" ]; then
-              if [ "${{ steps.candidate.outputs.channel }}" = "$alias" ]; then
-                cp "$dir/$asset" "$dir/libreecho-radar-puffin-${alias}.ota.tar"
-                assets+=("libreecho-radar-puffin-${alias}.ota.tar")
-              fi
+            if [ "$CANDIDATE_CHANNEL" = "$alias" ]; then
+              cp "$dir/$ota" "$dir/libreecho-radar-puffin-${alias}.ota.tar"
+              assets+=("libreecho-radar-puffin-${alias}.ota.tar")
             fi
           done
           printf '%s\n' "${assets[@]}" | sort -u >"$dir/.assets"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -70,7 +70,7 @@ jobs:
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-initial-install.tar"
           printf '%s\n' "${assets[@]}" | grep -qx "$sums"
           printf '%s\n' "${assets[@]}" | grep -qx "$ota"
-          grep -Eq "^[0-9a-fA-F]{64}[[:space:]]+${ota}$" "$dir/$sums"
+          awk -v ota="$ota" '$2 == ota && length($1) == 64 && $1 !~ /[^0-9a-fA-F]/ { found=1 } END { exit !found }' "$dir/$sums"
           (cd "$dir" && sha256sum -c "$sums")
           if printf '%s\n' "${assets[@]}" | grep -Eiq 'source-offer|provenance|\.spdx\.json|source-closure'; then
             echo 'unexpected compliance asset in public release' >&2; exit 1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,7 @@ jobs:
           for key in ('version','source_run_id','source_run_attempt'):
               if key not in data: raise SystemExit(f'missing candidate field: {key}')
               print(f'{key}={data[key]}')
+          print(f"channel={data.get('channel','stable')}")
           PY
       - name: Download exact Build staging artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -53,7 +54,7 @@ jobs:
           test -f "public-release/public-release/libreecho-${VERSION}-SHA256SUMS" || test -f "public-release/libreecho-${VERSION}-SHA256SUMS"
           dir=public-release/public-release
           test -d "$dir" || dir=public-release
-          mapfile -t assets < <(find "$dir" -maxdepth 1 -type f -printf '%f\n' | sort)
+          mapfile -t assets < <(find "$dir" -maxdepth 1 -type f -printf '%f\n' ! -name '.assets' | sort)
           test "${#assets[@]}" -ge 3
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-boot.img"
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-initial-install.tar"
@@ -62,6 +63,21 @@ jobs:
           if printf '%s\n' "${assets[@]}" | grep -Eiq 'source-offer|provenance|\.spdx\.json|source-closure'; then
             echo 'unexpected compliance asset in public release' >&2; exit 1
           fi
+          assets=("${assets[@]}")
+          assets=("${assets[@]}")
+          for alias in stable dev; do
+            asset="libreecho-${VERSION}.ota.tar"
+            if [ -f "$dir/$asset" ]; then
+              if [ "${{ steps.candidate.outputs.channel }}" = "$alias" ]; then
+                cp "$dir/$asset" "$dir/libreecho-radar-puffin-${alias}.ota.tar"
+                assets+=("libreecho-radar-puffin-${alias}.ota.tar")
+              fi
+            fi
+          done
+          printf '%s\n' "${assets[@]}" | sort -u >"$dir/.assets"
+          mapfile -t assets <"$dir/.assets"
+          (cd "$dir" && find . -maxdepth 1 -type f ! -name '*-SHA256SUMS' ! -name '.assets' -printf '%f\0' | sort -z | xargs -0 sha256sum >"libreecho-${VERSION}-SHA256SUMS")
+          mapfile -t assets < <(find "$dir" -maxdepth 1 -type f -printf '%f\n' ! -name '.assets' | sort)
           tag="$VERSION"
           release_id="$(gh release view "$tag" --json databaseId --jq .databaseId 2>/dev/null || true)"
           if [ -z "$release_id" ]; then

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -70,7 +70,7 @@ jobs:
           printf '%s\n' "${assets[@]}" | grep -qx "libreecho-${VERSION}-initial-install.tar"
           printf '%s\n' "${assets[@]}" | grep -qx "$sums"
           printf '%s\n' "${assets[@]}" | grep -qx "$ota"
-          grep -Fqx "  $ota" "$dir/$sums"
+          grep -Eq "^[0-9a-fA-F]{64}[[:space:]]+${ota}$" "$dir/$sums"
           (cd "$dir" && sha256sum -c "$sums")
           if printf '%s\n' "${assets[@]}" | grep -Eiq 'source-offer|provenance|\.spdx\.json|source-closure'; then
             echo 'unexpected compliance asset in public release' >&2; exit 1


### PR DESCRIPTION
## Summary
- derive the channel from the merged candidate record
- publish the expected libreecho-radar-puffin-{stable,dev}.ota.tar alias
- regenerate and verify checksums after alias creation

## Validation
- workflow YAML and diff checks pass

No merge or release publication.