### PR TITLE
release: radar-puffin-v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
-Release entries are added by the Build release candidate PR workflow.
+## radar-puffin-v0.1.0
+
+See release/radar-puffin-v0.1.0.md.

--- a/release/radar-puffin-v0.1.0-candidate.json
+++ b/release/radar-puffin-v0.1.0-candidate.json
@@ -1,0 +1,9 @@
+{
+  "schema": 1,
+  "version": "radar-puffin-v0.1.0",
+  "channel": "dev",
+  "build_repo": "aslater3/LibreEcho-Build",
+  "source_run_id": 31619476482,
+  "source_run_attempt": 1,
+  "release_notes": "release/radar-puffin-v0.1.0.md"
+}

--- a/release/radar-puffin-v0.1.0.md
+++ b/release/radar-puffin-v0.1.0.md
@@ -63,3 +63,9 @@ host image contract were independently verified before publication.
 Do not flash a raw or renamed artifact outside the reviewed LibreEcho deployment
 flow. Preserve a confirmed rollback slot and owner data, and treat successful
 host verification as distinct from device runtime acceptance.
+
+## Candidate
+
+Build candidate staged by run `31619476482` attempt `1`.
+
+The merge workflow publishes only the bounded `public-release/` artifact from that exact run.


### PR DESCRIPTION
## Release candidate

Build run: 31619476482 attempt 1

This candidate is for the dev channel. Merging triggers the protected Product release workflow, which downloads the exact Build artifact and publishes only bounded public files.

No hardware action is performed.