### PR TITLE
docs: add private security reporting policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,6 +8,7 @@ body:
     attributes:
       value: |
         Do not include passwords, API tokens, private keys, or unredacted personal data.
+        For a security vulnerability, use the [private security advisory route](https://github.com/aslater3/LibreEcho/security/advisories/new) instead of this public form.
   - type: input
     id: component
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Private security vulnerability report
+    url: https://github.com/aslater3/LibreEcho/security/advisories/new
+    about: Never disclose credentials or exploit details in a public issue; use the private advisory route.
   - name: LibreEcho-Platform implementation issues
     url: https://github.com/aslater3/LibreEcho-Platform/issues
     about: Use this for kernel, boot, Wi-Fi, image, or OTA implementation bugs.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 </div>
 
 The interface, API, and service daemons live in the separate
-[LibreEcho-UI](https://github.com/aslater3/LibreEcho-UI) repository.
+[LibreEcho-UI](https://github.com/aslater3/LibreEcho-UI) repository. That
+repository is currently private pending a public-safety and licence review;
+the public website does not present it as a logged-out source download.
 
 LibreEcho is an open embedded voice-assistant operating system focused on
 privacy, repairability, and local control. The current development line targets
@@ -36,6 +38,7 @@ integration continue on review branches.
 - **Control centre:** [LibreEcho-UI](https://github.com/aslater3/LibreEcho-UI)
 - **Hardware and OS:** [LibreEcho-Platform](https://github.com/aslater3/LibreEcho-Platform)
 - **Issues:** [report a reproducible product problem](https://github.com/aslater3/LibreEcho/issues/new/choose)
+- **Security:** [read the security policy](SECURITY.md) or [submit a private advisory](https://github.com/aslater3/LibreEcho/security/advisories/new)
 - **Support:** [buy me a coffee](https://buymeacoffee.com/libreecho)
 
 ## What Is Included
@@ -61,6 +64,10 @@ See [the repository boundary guide](docs/repositories.md) for where a change bel
 Use the issue tracker for reproducible bugs and hardware problems. Include the
 device model, OS version, active slot, relevant logs, and the smallest reliable
 reproduction. Do not include Wi-Fi passwords, API tokens, or private keys.
+
+Security vulnerabilities must not be filed publicly. Read
+[SECURITY.md](SECURITY.md) for the supported release scope, private reporting
+route, redaction requirements and release-withdrawal guidance.
 
 Once Discussions are enabled in the repository settings, use them for design
 questions, setup help, and ideas that are not yet actionable bugs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,14 @@ security vulnerabilities.
 
 ## Supported scope
 
-The currently supported public scope is the `radar-puffin v0.1.0` development
-release and the Linux 6.1 development line for the documented Echo Gen 2 target.
-The Developer Preview and Open Beta gates are separate release decisions; Open
-Beta has not launched. A fix may be developed on a later review branch before it
-is backported to a public release.
+The currently supported public scope includes the `radar-puffin v0.11.0`
+development release, the earlier `radar-puffin v0.1.0` development release, and
+the Linux 6.1 development line for the documented Echo Gen 2 target. For
+v0.11.0, use the signed OTA and initial-install artifacts published in its GitHub
+Release record; verify the matching `libreecho-radar-puffin-v0.11.0-SHA256SUMS`
+file before use. The Developer Preview and Open Beta gates are separate release
+decisions; Open Beta has not launched. A fix may be developed on a later review
+branch before it is backported to a public release.
 
 Security reports are especially important for:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security policy
+
+LibreEcho is an independent, volunteer-maintained project for recoverable
+Amazon Echo Gen 2 experimentation. Please do not use public GitHub issues for
+security vulnerabilities.
+
+## Supported scope
+
+The currently supported public scope is the `radar-puffin v0.1.0` development
+release and the Linux 6.1 development line for the documented Echo Gen 2 target.
+The Developer Preview and Open Beta gates are separate release decisions; Open
+Beta has not launched. A fix may be developed on a later review branch before it
+is backported to a public release.
+
+Security reports are especially important for:
+
+- authentication, session, CSRF or access-control bypasses;
+- OTA signature, rollback, update or release-identity verification;
+- remote control-plane or network-service exposure;
+- boot, recovery, privilege or arbitrary-write paths;
+- credentials, tokens, owner-local firmware or private diagnostic disclosure;
+- supply-chain, release workflow or third-party provenance issues.
+
+Direct public-Internet exposure of the device control plane is unsupported. That
+boundary does not make an access-control or data-disclosure report irrelevant;
+report it privately when it could affect a trusted-LAN deployment or release
+artifact.
+
+## Private reporting
+
+Use GitHub's private vulnerability reporting form:
+
+<https://github.com/aslater3/LibreEcho/security/advisories/new>
+
+Do not open a public issue, pull request or discussion with exploit details. If
+GitHub does not offer the private form, do not publish the vulnerability while
+waiting for the maintainer to enable or announce an alternative private route.
+The project does not treat a public issue as a substitute for confidential
+coordination.
+
+Include, where safe:
+
+- affected public release, tag or commit;
+- affected component and deployment context;
+- smallest reliable reproduction;
+- impact and realistic attack prerequisites;
+- redacted logs, traces or proof of concept;
+- whether the issue survives reboot, rollback or recovery;
+- a suggested mitigation, if known.
+
+Never include passwords, API tokens, private keys, Wi-Fi credentials, serials,
+MAC addresses, SSIDs, private IPs, owner-local firmware or unredacted device
+identities. Use placeholders and describe how maintainers can reproduce the
+condition safely.
+
+## Coordination expectations
+
+This is a volunteer project. Maintainers will acknowledge a private report when
+practical, validate the impact, coordinate a fix or mitigation, and agree on a
+public disclosure date with the reporter when a report is confirmed. Please do
+not publish exploit details, credentials or a vulnerable release's private
+artifacts before coordination is complete.
+
+Third-party vulnerabilities should also be reported to the relevant upstream
+project when LibreEcho is not the owner. Tell LibreEcho privately if the issue
+also affects a LibreEcho release or packaging decision.
+
+## Release withdrawal and rollback
+
+A confirmed release-blocking vulnerability may require pausing downloads,
+marking a release superseded, publishing mitigation guidance, or directing users
+to the confirmed A/B rollback slot. The public release record and
+<https://libreecho.org/> are the locations for sanitized withdrawal and rollback
+instructions; private report details remain private.
+
+## Ordinary bugs and questions
+
+Use the public issue tracker for reproducible non-sensitive bugs, with all
+secrets and identifying data removed. Use Discussions for design questions when
+it is enabled. The website's security and support page explains the routing and
+redaction checklist: <https://libreecho.org/#security>.


### PR DESCRIPTION
## Summary

Adds the canonical public security policy and links it from the README, issue-form configuration, and public bug template.

## Included

- Supported `radar-puffin v0.1.0` development-release scope and Developer Preview/Open Beta boundary
- GitHub private vulnerability reporting route
- Redaction requirements for credentials, device identities, network data, owner-local firmware, and diagnostics
- Ordinary bug versus security-report routing
- Third-party vulnerability handling
- Release withdrawal and A/B rollback communication guidance
- Public README and issue-template links

## Verification

- `python3 tools/test_release_tools.py` (20 tests passed)
- `python3 tools/check-public-metadata.py`
- `git diff --check`
- GitHub API verification: `GET /repos/aslater3/LibreEcho/private-vulnerability-reporting` returned `{"enabled":true}`

No device or release artifact was changed.
