### PR TITLE
test: remove obsolete production resolver assertions

### DIFF
--- a/build/tests/test_resolve_source_set.py
+++ b/build/tests/test_resolve_source_set.py
@@ -12,7 +12,6 @@ class Tests(unittest.TestCase):
  def test_all_four_shas_affect_id(self):
   x={k:'a'*40 for k in ('product','platform','linux','ui')}; y=dict(x); y['ui']='b'*40
   self.assertNotEqual(r.source_set_id(x),r.source_set_id(y))
- def test_production_tag(self): self.assertEqual(r.production_tag('1.2.3'),'radar-puffin-v1.2.3')
- def test_bad_version(self):
-  with self.assertRaises(ValueError): r.production_tag('v1.2.3')
+ def test_bad_sha(self):
+  with self.assertRaises(ValueError): r.validate_sha('not-a-sha')
 if __name__=='__main__': unittest.main()


### PR DESCRIPTION
## Summary
- removes two stale tests for the deleted production-version resolver path
- retains validation coverage for invalid source SHAs

## Changed files
- `build/tests/test_resolve_source_set.py`: align tests with the dev-only resolver merged in PR #58

## Testing
- `python3 tools/test_build_release_workflow.py` — 6 passed
- `python3 -m unittest discover -s build/tests -p 'test_*.py'` — 12 passed\n- `git diff --check` — passed\n\nRelease impact: none\nRelease note: none\n\nFollow-up to #58.