### PR TITLE
fix: download build artifacts before signing setup

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -407,6 +407,18 @@ jobs:
           path: sources/product
           fetch-depth: 1
           persist-credentials: false
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: public-deps-${{ needs.resolve-and-preflight.outputs.source_set_id }}
+          path: ${{ runner.temp }}/public-deps
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: public-toolchain-${{ needs.resolve-and-preflight.outputs.source_set_id }}
+          path: ${{ runner.temp }}/toolchain
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: armhf-root-${{ needs.resolve-and-preflight.outputs.source_set_id }}
+          path: ${{ runner.temp }}/armhf-root
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: '3.11'
@@ -457,18 +469,6 @@ jobs:
           test -n "$SSH_ROOT_PASSWORD_HASH"
           umask 077
           printf '%s\n' "$SSH_ROOT_PASSWORD_HASH" >"$RUNNER_TEMP/ssh-root-password-hash"
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        with:
-          name: public-deps-${{ needs.resolve-and-preflight.outputs.source_set_id }}
-          path: ${{ runner.temp }}/public-deps
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        with:
-          name: public-toolchain-${{ needs.resolve-and-preflight.outputs.source_set_id }}
-          path: ${{ runner.temp }}/toolchain
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        with:
-          name: armhf-root-${{ needs.resolve-and-preflight.outputs.source_set_id }}
-          path: ${{ runner.temp }}/armhf-root
       - name: Derive reviewed TTS voice models
         run: |
           set -euo pipefail

--- a/tools/test_build_release_workflow.py
+++ b/tools/test_build_release_workflow.py
@@ -259,6 +259,12 @@ class Tests(unittest.TestCase):
   self.assertIn('--tree "reviewed-connectivity=$PIPELINE/inputs/reviewed/connectivity"', B)
   # The vendored path must not invoke the musl toolchain rebuild anymore.
   self.assertNotIn('build_connectivity_helpers.sh', B)
+ def test_reviewed_signing_dependencies_are_downloaded_before_install(self):
+  build_image = W.index('  build-image:')
+  download = W.index('name: public-deps-${{ needs.resolve-and-preflight.outputs.source_set_id }}', build_image)
+  install = W.index('Install reviewed OTA signing dependency closure', build_image)
+  self.assertLess(download, install)
+
  def test_triggers_and_jobs(self):
   self.assertIn("branches: [main, 'release/**']",W); self.assertIn("cron: '17 3 * * *'",W); self.assertIn('workflow_dispatch:',W); self.assertIn('update_channel:',W); self.assertIn('release_version:',W); self.assertIn('signing_mode:',W)
   self.assertIn("SIGNING_MODE: ${{ github.event_name == 'pull_request' && 'github' || 'local' }}", W)


### PR DESCRIPTION
## Summary
- Fixes the Product workflow ordering bug that caused the secure OTA dependency step to run before the `public-deps` artifact existed.
- Downloads `public-deps`, `public-toolchain`, and `armhf-root` before Python setup and reviewed signing dependency installation.
- Adds a regression assertion scoped specifically to the `build-image` job.

## Root cause
The reviewed signing dependency step was placed before the three `actions/download-artifact` steps. The run therefore failed at `test -f "$RUNNER_TEMP/public-deps/SHA256SUMS"` before `pip` or OTA signing could run.

## Testing
- 51 Product tests passed.
- All three workflow YAML files parsed successfully.
- Shell and Python syntax checks passed.
- `git diff --check` passed.
- Regression test fails on the pre-fix ordering and passes after the fix.

Release impact: none
Release note: none

No signing key was accessed, no release was published, and no hardware action was performed.
