### PR TITLE
fix(installer): stage features on the device, and stop crashing while tailing amonet

### DIFF
--- a/tools/libreecho-install.py
+++ b/tools/libreecho-install.py
@@ -383,7 +383,16 @@ def run_amonet_with_progress(launcher: Path, cwd: Path, timeout: float) -> None:
         if log_path.exists():
             with log_path.open("r", encoding="utf-8", errors="replace") as stream:
                 stream.seek(log_offset)
-                for line in stream:
+                # Iterating a text file reads ahead, so tell() inside a
+                # `for line in stream` loop reports the end of the buffer
+                # rather than the end of this line. log_offset then jumped
+                # past lines that had not been examined yet and the next
+                # seek() skipped them, silently dropping progress states.
+                # readline() keeps tell() meaningful.
+                while True:
+                    line = stream.readline()
+                    if not line:
+                        break
                     log_offset = stream.tell()
                     message = _amonet_progress_message(line)
                     if message and message != last_state:
@@ -929,6 +938,11 @@ def stage_device_features(
     root_script = cache_root / "stage-feature-root.sh"
     root_script.write_text(ROOT_FEATURE_STAGER, encoding="utf-8")
     root_script.chmod(0o755)
+    # The stager has to exist ON THE DEVICE before `adb shell sh` can run it.
+    # Everything else here is pushed to /tmp first; this file was not, so the
+    # shell was handed a laptop path and every feature failed to stage.
+    remote_script = "/tmp/libreecho-stage-feature-root.sh"
+    _run_command([adb_bin, "-s", serial, "push", str(root_script), remote_script], timeout)
     for feature in manifest["features"]:
         name = feature["name"]
         payload = payload_root / feature["payload"]["name"]
@@ -951,7 +965,7 @@ def stage_device_features(
         )
         config.chmod(0o600)
         _run_command([adb_bin, "-s", serial, "push", str(config), "/tmp/libreecho-feature-stage.conf"], timeout)
-        result = _run_command([adb_bin, "-s", serial, "shell", "sh", str(root_script)], timeout, check=False)
+        result = _run_command([adb_bin, "-s", serial, "shell", "sh", remote_script], timeout, check=False)
         if result.returncode != 0 or f"FEATURE_STAGE_OK:{name}" not in result.stdout:
             detail = (result.stderr or result.stdout).strip()[-500:]
             raise InstallerError(f"feature staging failed for {name}: {detail}")


### PR DESCRIPTION
Two defects on the first-install path. Both are on `main` today and both are reachable by anyone running a release installer unmodified.

## 1. Feature staging can never succeed

`stage-feature-root.sh` is written into the **host** cache and then executed with:

```python
root_script = cache_root / "stage-feature-root.sh"      # a laptop path
...
result = _run_command([adb_bin, "-s", serial, "shell", "sh", str(root_script)], ...)
```

The device has no such file. Note the asymmetry with everything else in that same loop — the payload, its manifest and the generated config are each `adb push`ed to `/tmp/libreecho-*` before use; only the stager is not. The shell is handed a path it cannot open, the return code is non-zero, and staging raises `feature staging failed for <name>` for **every** feature.

Fixed by pushing the stager alongside the rest and running the pushed copy.

## 2. Tailing amonet's log raises

```python
for line in stream:
    log_offset = stream.tell()
```

`tell()` inside `for line in stream` is an error on a text file — iteration reads ahead, so the position is not meaningful and CPython refuses it outright:

```
OSError: telling position disabled by next() call
```

Reproduced against the shipped code path. The only `try/except OSError` in `run_amonet_with_progress` guards `subprocess.Popen`, so this propagates **uncaught** the moment amonet appends a line: the installer dies with a bare traceback in the middle of the handoff it is meant to be narrating. `readline()` keeps `tell()` well defined and preserves the resume-from-offset behaviour the polling loop depends on.

## How these were found

By diffing a release installer against a working install. The only successful install we have a record of was done with a locally patched copy carrying these same two changes — which is why neither has been hit in-house, and why the unpatched path has effectively never been exercised end to end.