### PR TITLE
feat: package nightly one-shot installer assets

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -127,7 +127,11 @@ jobs:
           fi
           mapfile -t assets < <(find release-assets -maxdepth 1 -type f -printf '%p\n' | sort)
           expected_asset_count=14
-          [[ "$RELEASE_SIGNED" == 1 ]] && expected_asset_count=15
+          if [[ "$RELEASE_KIND" == nightly ]]; then
+            expected_asset_count=19
+          elif [[ "$RELEASE_SIGNED" == 1 ]]; then
+            expected_asset_count=15
+          fi
           test "${#assets[@]}" -eq "$expected_asset_count"
           gh release upload "$tag" "${assets[@]}"
           gh api "repos/$GITHUB_REPOSITORY/releases/$release_id/assets" --paginate \

--- a/build/ci/prepare-dev-release.py
+++ b/build/ci/prepare-dev-release.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import io
 import json
 import re
 import shutil
+import tarfile
 from pathlib import Path
 
 COMMIT = re.compile(r"^[0-9a-f]{40}$")
@@ -52,6 +54,139 @@ def find_run(root: Path) -> Path:
     if len(matches) != 1:
         fail(f"expected one hosted run, found {len(matches)}")
     return matches[0]
+
+
+def prepare_nightly_initial_install(
+    run: Path,
+    output: Path,
+    candidate: dict[str, str],
+    sources: dict[str, str],
+    verification: Path,
+    ota: Path,
+    source_set_id: str,
+    artifact_set_id: str,
+) -> tuple[str, int]:
+    """Add the complete one-shot asset set to a nightly release."""
+    product = Path(__file__).resolve().parents[2]
+    installer = product / "tools" / "libreecho-install.py"
+    ota_key = run / "ota-public-key.hex"
+    if not ota_key.is_file():
+        fail("nightly candidate is missing ota-public-key.hex")
+    if not installer.is_file():
+        fail("Product installer source is missing")
+    release_tag = f"radar-puffin-nightly-{candidate['product_git_head'][:7]}-{source_set_id}-{artifact_set_id}"
+    prefix = f"libreecho-{release_tag}"
+    sources_dir = run / "features"
+    if not sources_dir.is_dir():
+        fail("nightly candidate is missing its features directory")
+    files: list[tuple[str, Path]] = [
+        (f"{prefix}-boot.img", run / "boot.img"),
+        (f"{prefix}.ota.tar", ota),
+        (f"{prefix}-installer.py", installer),
+        (f"{prefix}-ota-public-key.hex", ota_key),
+        (f"{prefix}-verification.txt", verification),
+    ]
+    for feature in FEATURES:
+        files.extend((
+            (f"{prefix}-{feature}.squashfs", sources_dir / f"{feature}.squashfs"),
+            (f"{prefix}-{feature}.manifest.json", sources_dir / f"{feature}.manifest.json"),
+        ))
+    for target_name, source in files:
+        regular(source)
+        expected = ""
+        if target_name.endswith("-boot.img"):
+            expected = candidate.get("boot_image_sha256", "")
+        elif target_name.endswith(".ota.tar"):
+            expected = candidate.get("ota_bundle_sha256", "")
+        elif target_name.endswith("-installer.py"):
+            expected = sha256(source)
+        elif target_name.endswith("-ota-public-key.hex"):
+            expected = sha256(source)
+        elif target_name.endswith("-verification.txt"):
+            expected = sha256(source)
+        else:
+            if target_name.endswith(".squashfs"):
+                feature = target_name.removeprefix(prefix + "-").removesuffix(".squashfs")
+                key = "airplay" if feature == "airplay2" else feature
+                expected = candidate.get(f"{key}_payload_sha256", "")
+            else:
+                feature = target_name.removeprefix(prefix + "-").removesuffix(".manifest.json")
+                key = "airplay" if feature == "airplay2" else feature
+                expected = candidate.get(f"{key}_feature_manifest_sha256", "")
+        expect_hash(source, expected)
+        shutil.copyfile(source, output / target_name)
+
+    records = {
+        name: {"name": name, "size": (output / name).stat().st_size, "sha256": sha256(output / name)}
+        for name, _ in files
+    }
+    manifest = {
+        "schema": "libreecho-initial-install-v1",
+        "release": release_tag,
+        "board": "radar_puffin",
+        "soc": "mt8163",
+        "image_profile": "ota",
+        "service_profile": "production",
+        "boot": records[f"{prefix}-boot.img"],
+        "ota_public_key": records[f"{prefix}-ota-public-key.hex"],
+        "features": [
+            {"name": feature, "payload": records[f"{prefix}-{feature}.squashfs"],
+             "manifest": records[f"{prefix}-{feature}.manifest.json"]}
+            for feature in FEATURES
+        ],
+        "amonet": {
+            "repository": "https://github.com/aslater3/amonet-k32",
+            "tag": "dfefe52f0eed7296012707cfff1f753b0ea33257",
+            "commit": "dfefe52f0eed7296012707cfff1f753b0ea33257",
+        },
+    }
+    bundle = output / f"{prefix}-initial-install.tar"
+    bundle_members = [
+        f"{prefix}-boot.img", f"{prefix}-ota-public-key.hex",
+        *[f"{prefix}-{feature}.{suffix}" for feature in FEATURES for suffix in ("squashfs", "manifest.json")],
+    ]
+    manifest_bytes = (json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    with tarfile.open(bundle, "w") as archive:
+        info = tarfile.TarInfo("manifest.json")
+        info.size = len(manifest_bytes)
+        info.mode = 0o644
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name in bundle_members:
+            path = output / name
+            info = tarfile.TarInfo(name)
+            info.size = path.stat().st_size
+            info.mode = 0o644
+            with path.open("rb") as stream:
+                archive.addfile(info, stream)
+
+    build_manifest = {
+        "schema": "libreecho-development-build-v1",
+        "build_id": f"{source_set_id}-{artifact_set_id}",
+        "source_set_id": source_set_id,
+        "artifact_set_id": artifact_set_id,
+        "board": "radar_puffin",
+        "channel": "dev",
+        "kind": "nightly",
+        "status": "PREPARED_NOT_FLASHED",
+        "signed": True,
+        "ota_bundle": True,
+        "hardware_accepted": False,
+        "feature_policy": "community-noncommercial",
+        "sources": sources,
+        "artifacts": [records[name] for name, _ in files],
+    }
+    (output / f"{prefix}-build.json").write_text(json.dumps(build_manifest, indent=2, sort_keys=True) + "\n")
+    notes = output / f"{prefix}-release-notes.md"
+    notes.write_text(
+        f"# LibreEcho nightly {release_tag}\n\n"
+        "This is a signed development nightly for controlled hardware testing. "
+        "It includes the complete one-shot installer asset set. Status: "
+        "PREPARED_NOT_FLASHED; no hardware acceptance is implied.\n"
+    )
+    all_files = sorted(path for path in output.iterdir() if path.is_file())
+    sums = output / f"{prefix}-SHA256SUMS"
+    sums.write_text("".join(f"{sha256(path)}  {path.name}\n" for path in all_files), encoding="ascii")
+    return release_tag, len(all_files) + 1
 
 
 def main() -> int:
@@ -231,6 +366,25 @@ def main() -> int:
     sums.write_text("".join(
         f"{sha256(path)}  {path.name}\n" for path in sorted(copied)
     ), encoding="ascii")
+    if args.release_kind == "nightly":
+        if not signed or len(ota_bundles) != 1:
+            fail("nightly one-shot artifact requires exactly one signed OTA")
+        for path in output.iterdir():
+            if path.is_file():
+                path.unlink()
+        release_tag, asset_count = prepare_nightly_initial_install(
+            run, output, candidate, sources, verification, ota_bundles[0],
+            source_set_id, artifact_set_id,
+        )
+        print(f"release_dir={output}")
+        print(f"release_tag={release_tag}")
+        print(f"release_prefix=libreecho-{release_tag}")
+        print(f"source_set_id={source_set_id}")
+        print(f"artifact_set_id={artifact_set_id}")
+        print(f"asset_count={asset_count}")
+        print("signed=1")
+        print("ota_bundle=1")
+        return 0
     print(f"release_dir={output}")
     print(f"release_tag={release_tag_prefix}-{args.product_commit[:7]}-{source_set_id}-{artifact_set_id}")
     print(f"release_prefix={prefix}")

--- a/build/tests/test_prepare_dev_release.py
+++ b/build/tests/test_prepare_dev_release.py
@@ -114,7 +114,16 @@ class Tests(unittest.TestCase):
     def test_prepares_bounded_unsigned_nightly_release(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
-            _, commits = fixture(root)
+            run, commits = fixture(root)
+            ota = run / "nightly.ota.tar"
+            ota.write_bytes(b"signed nightly ota")
+            candidate = run / "CURRENT.candidate"
+            text = candidate.read_text()
+            text = text.replace("ota_signing_mode=github\n", "ota_signing_mode=local\n")
+            text = text.replace("ota_bundle=\n", "ota_bundle=" + str(ota) + "\n")
+            text = text.replace("ota_bundle_sha256=\n", "ota_bundle_sha256=" + digest(ota) + "\n")
+            candidate.write_text(text)
+            (run / "ota-public-key.hex").write_text("a" * 64 + "\n")
             output = root / "release"
             result = subprocess.run([
                 sys.executable, str(SCRIPT),
@@ -124,7 +133,11 @@ class Tests(unittest.TestCase):
                 "--release-kind", "nightly",
             ], text=True, capture_output=True)
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn("release_tag=radar-puffin-nightly-", result.stdout)
+            files = {path.name for path in output.iterdir()}
+            self.assertEqual(len(files), 19)
+            self.assertIn("-initial-install.tar", next(name for name in files if name.endswith("-initial-install.tar")))
+            self.assertTrue(any(name.endswith("-installer.py") for name in files))
+            self.assertIn("asset_count=19", result.stdout)
 
     def test_prepares_signed_dev_release_with_ota_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/release/README.md
+++ b/release/README.md
@@ -9,19 +9,27 @@ Amonet/BROM wrapper image, calibration data, or local filesystem path.
 
 Hosted main-branch builds produce a bounded `dev`-channel prerelease. Pull
 requests remain unsigned validation-only builds, but successful pushes to
-`main` and scheduled nightly runs produce a **signed development OTA** from the
-exact verified Product workflow artifact. These dev/nightly releases contain
-the signed OTA bundle, verified boot image, five feature payloads and manifests,
-a sanitized source/build manifest, the independent verifier result, and a
-SHA-256 inventory. Their non-SemVer tags bind the product commit plus complete
-source-set and artifact-set digests, preventing a later rebuild from replacing
-different bytes under an existing public identity.
+`main` and scheduled nightly runs produce a signed development OTA and related
+artifacts from the exact verified Product workflow artifact. Nightly releases
+additionally contain an initial-install bundle, installer, public OTA key, release
+notes, and complete SHA-256 inventory so a controlled fresh-install test can use
+the nightly without creating a stable Product release.
+
+A nightly initial-install test uses the published nightly tag and its bundled
+installer:
+
+```bash
+python3 libreecho-radar-puffin-nightly-<build-id>-installer.py one-shot \\
+  --release-tag radar-puffin-nightly-<build-id> \\
+  --fastboot-serial auto --slots both --execute-hardware
+```
 
 A signed dev/nightly release is usable only by devices deliberately switched to
 the `dev` OTA channel. It remains a GitHub prerelease, is never marked `latest`,
-and makes no stable-product, flashing, deployment, or hardware-acceptance
-claim. This development distribution path is signed for beta OTA testing but
-remains distinct from the stable release boundary below.
+and makes no stable-product, flashing, deployment, or hardware-acceptance claim.
+Nightly releases are controlled hardware-test prereleases only; they do not
+imply general hardware acceptance.
+
 
 A complete `community-noncommercial` release has two layers:
 

--- a/tools/libreecho-install.py
+++ b/tools/libreecho-install.py
@@ -25,7 +25,7 @@ from typing import Any
 PHASE = "RELEASE_READY"
 SCHEMA = "libreecho-initial-install-v1"
 SHA256 = re.compile(r"[0-9a-f]{64}")
-RELEASE = re.compile(r"radar-puffin-v[0-9]+\.[0-9]+\.[0-9]+")
+RELEASE = re.compile(r"radar-puffin-(?:v[0-9]+\.[0-9]+\.[0-9]+|nightly-[0-9a-f-]+)")
 PUBLIC_NAME = re.compile(r"[A-Za-z0-9._-]+")
 
 
@@ -684,6 +684,8 @@ def _prepare(release_dir: Path, cache_root: Path, release_tag: str) -> tuple[dic
         expected.add(ota_asset.name)
     records = _checksums(checksums, None)
     optional = {"libreecho-radar-puffin-dev.ota.tar"}
+    if release_tag.startswith("radar-puffin-nightly-"):
+        optional.update({f"{prefix}-build.json", f"{prefix}-verification.txt"})
     unexpected = set(records) - expected - optional
     if not expected.issubset(records) or unexpected:
         raise InstallerError("checksum inventory mismatch")

--- a/tools/libreecho-install.py.sha256
+++ b/tools/libreecho-install.py.sha256
@@ -1,1 +1,1 @@
-c7eb413cadcf55815ab88fcbc8f51976908a6799563b7d3477967e9aa765db5d  libreecho-install.py
+7e7cc0c1c170fb7e59f96ee2679057d57f0655683349bbf106e7bfac980ed7a1  libreecho-install.py

--- a/tools/test_build_release_workflow.py
+++ b/tools/test_build_release_workflow.py
@@ -298,6 +298,7 @@ class Tests(unittest.TestCase):
   self.assertIn("'.object.type == \"commit\" and .object.sha == $sha'", PUBLISH)
   self.assertIn('expected_asset_count=14', PUBLISH)
   self.assertIn('expected_asset_count=15', PUBLISH)
+  self.assertIn('expected_asset_count=19', PUBLISH)
   self.assertIn('prepare-stable-release.py', PUBLISH)
   self.assertIn('publish-stable:', PUBLISH)
   self.assertIn("github.event.workflow_run.event == 'workflow_dispatch'", PUBLISH)
@@ -334,7 +335,9 @@ class Tests(unittest.TestCase):
   self.assertIn('CC-BY-NC-SA-4.0', (ROOT/'build/ci/generate-release-notes.py').read_text())
   self.assertIn('No local release command', (ROOT/'build/README.md').read_text())
 
- def test_boundaries(self):
+ def test_nightly_release_tag_is_accepted(self):
+  installer = (ROOT/'tools/libreecho-install.py').read_text()
+  self.assertIn('nightly-[0-9a-f-]+', installer)
   # Concurrency is scoped per event and ref (independent PR lanes), and
   # running builds are never cancelled.
   self.assertIn('github.head_ref || github.ref',W); self.assertIn('cancel-in-progress: false',W)


### PR DESCRIPTION
## Summary
- package scheduled nightly releases with the complete one-shot install asset set
- make nightly release tags consumable by `tools/libreecho-install.py`
- keep normal development-release asset behavior unchanged

## Root cause
Nightly publishing previously emitted the OTA, boot image, feature payloads, and build metadata, but omitted the installer, initial-install bundle, public OTA key, and release notes. The installer therefore rejected the nightly checksum inventory.

## Changed files
- `.github/workflows/publish-release.yml`: require the 19-asset nightly inventory.
- `build/ci/prepare-dev-release.py`: construct a tag-prefixed nightly installer package, signed OTA bundle, five feature payloads/manifests, public key, notes, build metadata, and checksums.
- `tools/libreecho-install.py`: accept the immutable `radar-puffin-nightly-*` tag format and the nightly metadata files.
- `tools/libreecho-install.py.sha256`: update the mirror checksum.
- regression tests: cover nightly packaging, tag acceptance, and asset-count behavior.
- `release/README.md`: document controlled nightly initial-install usage.

## Verification
- `python3 -B -m unittest -q build.tests.test_prepare_dev_release tools.test_build_release_workflow tools.test_release_tools tools.test_initial_installer_publication` — 35 passed.
- Python compilation passed for changed Python files.
- YAML parsing passed for both Product workflows.
- `git diff --check` passed.
- synthetic nightly output was consumed successfully by the Product `main` installer contract: 5 features and initial-install bundle verified.
- no hardware touched.

Release impact: patch

Release note: Scheduled nightly releases now include the complete verified one-shot installer asset set for controlled fresh-install testing.
