### PR TITLE
docs: link Echo Gen 2 disassembly guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ validation, but the project is not yet presented as a general-purpose upstream
 Linux port or a stable public OTA release. Hardware fixes and service
 integration continue on review branches.
 
+## Getting Started
+
+- **Echo Gen 2 disassembly:** [follow the disassembly guide](docs/disassembly/echo-gen-2/README.md)
+
 ## Start Here
 
 - **Website:** [libreecho.org](https://libreecho.org/)


### PR DESCRIPTION
## Summary
- Add a Getting Started section to the main README.
- Link readers to the Echo Gen 2 disassembly guide.

## Changed files
- `README.md` — add the requested disassembly-guide link; installation steps are intentionally deferred.

## Testing and evidence
- `test -f docs/disassembly/echo-gen-2/README.md`
- `git diff --check`

Release impact: none
Release note: none