### PR TITLE
fix(installer): fail fast on BROM serial permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -184,6 +184,7 @@ jobs:
             build.tests.test_generate_release_notes \
             build.tests.test_resolve_source_set \
             tools.test_build_release_workflow \
+            tools.test_brom_preflight \
             tools.test_initial_installer_publication \
             tools.test_release_tools
       - name: Validate tracked source syntax

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -15,6 +15,7 @@ on:
       - 'tools/libreecho-install.py'
       - 'tools/libreecho-install.py.sha256'
       - 'tools/test_initial_installer_publication.py'
+      - 'tools/test_brom_preflight.py'
       - '.github/workflows/release-gate.yml'
       - '.github/workflows/publish-release.yml'
   push:
@@ -32,6 +33,7 @@ on:
       - 'tools/libreecho-install.py'
       - 'tools/libreecho-install.py.sha256'
       - 'tools/test_initial_installer_publication.py'
+      - 'tools/test_brom_preflight.py'
       - '.github/workflows/release-gate.yml'
       - '.github/workflows/publish-release.yml'
   workflow_dispatch:
@@ -66,7 +68,8 @@ jobs:
             tools/check-public-metadata.py \
             tools/test_release_tools.py \
             tools/libreecho-install.py \
-            tools/test_initial_installer_publication.py
+            tools/test_initial_installer_publication.py \
+            tools/test_brom_preflight.py
       - name: Reject private identifiers in public metadata
         run: python3 tools/check-public-metadata.py
       - name: Enforce full component and SBOM gate
@@ -82,3 +85,5 @@ jobs:
             --release-scope community-noncommercial
       - name: Verify public installer mirror
         run: python -B -m unittest tools.test_initial_installer_publication -v
+      - name: Verify BROM permission preflight suite
+        run: python -B -m unittest tools.test_brom_preflight -v

--- a/tools/libreecho-install.py
+++ b/tools/libreecho-install.py
@@ -454,7 +454,10 @@ def _print_brom_transport_diagnostics() -> None:
             except OSError:
                 continue
         mt = {slot: vidpid for slot, vidpid in media_tek.items() if vidpid[0] == "0e8d"}
-        nodes = [node.name for node in _tty_nodes()]
+        brom_present = any(pid == "0003" for _, pid in mt.values())
+        all_nodes = [node.name for node in _tty_nodes()]
+        nodes = [name for name in all_nodes if _tty_is_media_tek(pathlib.Path("/dev") / name)]
+        unrelated = [name for name in all_nodes if name not in nodes]
         print("--- BROM transport diagnostics ---", flush=True)
         if not mt:
             print("no MediaTek USB device is currently enumerated.", flush=True)
@@ -467,12 +470,20 @@ def _print_brom_transport_diagnostics() -> None:
             }.get((vid, pid), "MediaTek device in an unrecognized state")
             print(f"usb {slot}: {vid}:{pid} - {meaning}", flush=True)
         if nodes:
-            print(f"serial nodes present: {', '.join(nodes)}", flush=True)
-            if not mt:
-                print("note: an enumerated BROM is missing - those serial nodes are unrelated devices.", flush=True)
+            print(f"MediaTek serial nodes present: {', '.join(nodes)}", flush=True)
+        elif brom_present and unrelated:
+            print(
+                "the /dev/ttyACM* nodes present ({}) are NOT MediaTek devices - "
+                "BROM has no usable serial node.".format(", ".join(unrelated)),
+                flush=True,
+            )
+        elif brom_present:
+            print("no /dev/ttyACM* node exists on this host.", flush=True)
+        elif unrelated:
+            print(f"(unrelated serial nodes ignored: {', '.join(unrelated)})", flush=True)
         else:
             print("no /dev/ttyACM* node exists on this host.", flush=True)
-        if any(pid == "0003" for _, pid in mt.values()) and not nodes:
+        if brom_present and not nodes:
             print(
                 "BROM is enumerated but has no CDC serial node: check 'lsmod | grep cdc_acm', "
                 "check dmesg for 'usb ... attached', and confirm no other service grabbed the port.",

--- a/tools/libreecho-install.py
+++ b/tools/libreecho-install.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import grp
 import hashlib
 import json
 import os
@@ -365,7 +366,137 @@ def _amonet_progress_message(line: str) -> str | None:
     return None
 
 
+def _tty_nodes():
+    return sorted(pathlib.Path("/dev").glob("ttyACM*"))
+
+
+def _tty_is_media_tek(node: Path) -> bool:
+    """True if /dev/ttyACMn traces to USB vendor 0e8d via sysfs."""
+    try:
+        resolved = (pathlib.Path("/sys/class/tty") / node.name / "device").resolve(strict=True)
+    except OSError:
+        return False
+    for parent in (resolved,) + tuple(resolved.parents):
+        vendor = parent / "idVendor"
+        if vendor.is_file():
+            try:
+                return vendor.read_text(encoding="ascii").strip().lower() == "0e8d"
+            except OSError:
+                return False
+    return False
+
+
+def brom_permission_preflight() -> None:
+    """Fail fast if any MediaTek CDC node is not openable read/write.
+
+    A MediaTek BROM device appears as /dev/ttyACM* owned root:dialout (or
+    root:uucp on some distros) with 0660 mode. When the running user cannot
+    open it, Amonet's port scan silently skips it and the user is stranded on
+    'waiting for BROM' with no error. The only reliable check is the same
+    read/write open the session will later perform. Nodes belonging to other
+    vendors are ignored - they are never the install target.
+    """
+    if os.geteuid() == 0:
+        return  # root always wins; no false alarm
+    blocked = []
+    for node in _tty_nodes():
+        if not _tty_is_media_tek(node):
+            continue
+        try:
+            fd = os.open(node, os.O_RDWR | os.O_NONBLOCK)
+        except PermissionError:
+            blocked.append(node.name)
+        except FileNotFoundError:
+            continue  # vanished between enumeration and open
+        except OSError as error:
+            # Node exists but cannot service an open (ENXIO before carrier,
+            # EBUSY under another driver). Not a permissions failure; Amonet
+            # classifies those itself, so surface and continue.
+            print(f"note: {node.name} read/write preflight hit OSError: {error}", flush=True)
+        else:
+            os.close(fd)
+    if not blocked:
+        return
+    lines = [
+        "cannot open MediaTek serial device(s) {} for read/write: permission denied for uid {}.".format(
+            ", ".join(blocked), os.getuid()
+        ),
+        "A BROM session needs read/write access to /dev/ttyACM*.",
+        "Fix (persistent): add this user to the serial group and start a NEW login session:",
+        "    sudo usermod -aG dialout $USER   # Debian/Ubuntu (uucp on Arch; lock on some distros)",
+        "Fix (this command only):",
+        "    sudo python3 <installer> one-shot ...",
+    ]
+    raise InstallerError("\n".join(lines))
+
+
+def _running_process_names():
+    names = set()
+    for entry in pathlib.Path("/proc").glob("[0-9]*/comm"):
+        try:
+            names.add(entry.read_text(encoding="utf-8").strip())
+        except OSError:
+            continue
+    return names
+
+
+def _print_brom_transport_diagnostics() -> None:
+    """Classify host-side BROM transport state; best-effort, never raises."""
+    try:
+        media_tek = {}
+        for vendor_path in pathlib.Path("/sys/bus/usb/devices").glob("*/idVendor"):
+            try:
+                product_path = vendor_path.with_name("idProduct")
+                media_tek[vendor_path.parent.name] = (
+                    vendor_path.read_text(encoding="ascii").strip(),
+                    product_path.read_text(encoding="ascii").strip(),
+                )
+            except OSError:
+                continue
+        mt = {slot: vidpid for slot, vidpid in media_tek.items() if vidpid[0] == "0e8d"}
+        nodes = [node.name for node in _tty_nodes()]
+        print("--- BROM transport diagnostics ---", flush=True)
+        if not mt:
+            print("no MediaTek USB device is currently enumerated.", flush=True)
+        for slot, (vid, pid) in sorted(mt.items()):
+            meaning = {
+                ("0e8d", "0003"): "MediaTek BROM (correct state)",
+                ("0e8d", "2000"): "stock preloader, NOT BROM (short/power-on sequence did not hold)",
+                ("0e8d", "2001"): "preloader, NOT BROM",
+                ("0e8d", "2008"): "AEOOT (deep error state; see docs)",
+            }.get((vid, pid), "MediaTek device in an unrecognized state")
+            print(f"usb {slot}: {vid}:{pid} - {meaning}", flush=True)
+        if nodes:
+            print(f"serial nodes present: {', '.join(nodes)}", flush=True)
+            if not mt:
+                print("note: an enumerated BROM is missing - those serial nodes are unrelated devices.", flush=True)
+        else:
+            print("no /dev/ttyACM* node exists on this host.", flush=True)
+        if any(pid == "0003" for _, pid in mt.values()) and not nodes:
+            print(
+                "BROM is enumerated but has no CDC serial node: check 'lsmod | grep cdc_acm', "
+                "check dmesg for 'usb ... attached', and confirm no other service grabbed the port.",
+                flush=True,
+            )
+        if "ModemManager" in _running_process_names():
+            print(
+                "ModemManager is running; it can open and hold new ttyACM ports. "
+                "If it repeatedly probes the BROM port, consider temporarily stopping it "
+                "(sudo systemctl stop ModemManager) during the handoff.",
+                flush=True,
+            )
+        print(
+            "remedy if nothing helps: cold power-off, apply the CLK-to-GND short, keep it applied "
+            "while reconnecting power/USB, and only then start the installer.",
+            flush=True,
+        )
+        print("--- end BROM diagnostics ---", flush=True)
+    except Exception as error:  # diagnostics must never mask the real failure
+        print(f"(BROM transport diagnostics unavailable: {error})", flush=True)
+
+
 def run_amonet_with_progress(launcher: Path, cwd: Path, timeout: float) -> None:
+    brom_permission_preflight()
     print("Amonet handoff started; monitoring its live progress.", flush=True)
     print("ACTION: power off the Echo, hold the marked CLK-to-GND short while applying power/USB, then release after BROM enumerates.", flush=True)
     print("Amonet status: waiting for BROM/USB...", flush=True)
@@ -379,6 +510,8 @@ def run_amonet_with_progress(launcher: Path, cwd: Path, timeout: float) -> None:
     last_notice = time.monotonic()
     deadline = time.monotonic() + timeout
     next_notice = time.monotonic() + 10
+    usb_stall_reported = False
+    last_permission_check = 0.0
     while True:
         if log_path.exists():
             with log_path.open("r", encoding="utf-8", errors="replace") as stream:
@@ -400,12 +533,33 @@ def run_amonet_with_progress(launcher: Path, cwd: Path, timeout: float) -> None:
                         last_state = message
                         last_notice = time.monotonic()
                         next_notice = last_notice + 10
+                        usb_stall_reported = False
         returncode = process.poll()
         if returncode is not None:
             if returncode != 0:
+                _print_brom_transport_diagnostics()
                 raise InstallerError(f"Amonet handoff failed with exit code {returncode}")
             return
         now = time.monotonic()
+        if now - last_permission_check >= 5:
+            # The device is connected AFTER the script starts, so this must
+            # re-check during the wait, not just once at launch. If the user
+            # cannot open a freshly enumerated MediaTek CDC node, stop now
+            # with an actionable message instead of a silent 900s hang.
+            last_permission_check = now
+            try:
+                brom_permission_preflight()
+            except InstallerError:
+                process.kill()
+                process.wait()
+                _print_brom_transport_diagnostics()
+                raise
+        if not usb_stall_reported and now - last_notice >= 30:
+            # Still at 'waiting for BROM' after 30s: classify what the host
+            # actually sees so the user learns WHY, instead of staring at the
+            # spinner until the 900s timeout.
+            _print_brom_transport_diagnostics()
+            usb_stall_reported = True
         if now >= deadline:
             process.kill()
             process.wait()

--- a/tools/libreecho-install.py.sha256
+++ b/tools/libreecho-install.py.sha256
@@ -1,1 +1,1 @@
-27d2dfe12b2273f0c78319d0af1c70a1c024bb3fd1b9445181373fa40d1e326c  libreecho-install.py
+64becedec87668a5376882b6d26a3e36a827cdcfc9e74951f63e8d8916de86a3  libreecho-install.py

--- a/tools/libreecho-install.py.sha256
+++ b/tools/libreecho-install.py.sha256
@@ -1,1 +1,1 @@
-64becedec87668a5376882b6d26a3e36a827cdcfc9e74951f63e8d8916de86a3  libreecho-install.py
+4aa92a20c458605b48305891d12e6cdba462e6fb7ad8a19d5fdc51010d1214e7  libreecho-install.py

--- a/tools/test_brom_preflight.py
+++ b/tools/test_brom_preflight.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""BROM permission preflight and transport diagnostics (host-only)."""
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _installer():
+    spec = importlib.util.spec_from_file_location(
+        "libreecho_install_preflight", ROOT / "tools" / "libreecho-install.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+INSTALLER = _installer()
+
+
+def fake_node(name: str):
+    return pathlib.Path("/dev") / name
+
+
+class PermissionPreflightTests(unittest.TestCase):
+    def test_no_nodes_is_quiet(self) -> None:
+        with mock.patch.object(INSTALLER, "_tty_nodes", return_value=[]):
+            INSTALLER.brom_permission_preflight()
+
+    def test_non_media_tek_node_is_ignored(self) -> None:
+        node = fake_node("ttyACM0")
+        with mock.patch.object(INSTALLER, "_tty_nodes", return_value=[node]), \
+             mock.patch.object(INSTALLER, "_tty_is_media_tek", return_value=False), \
+             mock.patch.object(os, "open", side_effect=PermissionError) as opener:
+            INSTALLER.brom_permission_preflight()
+        opener.assert_not_called()
+
+    def test_blocked_media_tek_node_raises_actionable_error(self) -> None:
+        node = fake_node("ttyACM0")
+        with mock.patch.object(INSTALLER, "_tty_nodes", return_value=[node]), \
+             mock.patch.object(INSTALLER, "_tty_is_media_tek", return_value=True), \
+             mock.patch.object(os, "geteuid", return_value=1000), \
+             mock.patch.object(os, "open", side_effect=PermissionError):
+            with self.assertRaises(INSTALLER.InstallerError) as caught:
+                INSTALLER.brom_permission_preflight()
+        message = str(caught.exception)
+        self.assertIn("ttyACM0", message)
+        self.assertIn("permission denied", message)
+        self.assertIn("usermod -aG dialout", message)
+        self.assertIn("sudo python3", message)
+
+    def test_openable_media_tek_node_passes(self) -> None:
+        node = fake_node("ttyACM0")
+        with mock.patch.object(INSTALLER, "_tty_nodes", return_value=[node]), \
+             mock.patch.object(INSTALLER, "_tty_is_media_tek", return_value=True), \
+             mock.patch.object(os, "geteuid", return_value=1000), \
+             mock.patch.object(os, "open", return_value=7) as opener, \
+             mock.patch.object(os, "close") as closer:
+            INSTALLER.brom_permission_preflight()
+        closer.assert_called_once_with(7)
+        self.assertEqual(opener.call_args.args[0], node)
+
+    def test_root_skips_preflight(self) -> None:
+        with mock.patch.object(os, "geteuid", return_value=0), \
+             mock.patch.object(INSTALLER, "_tty_nodes", side_effect=AssertionError("must not scan")):
+            INSTALLER.brom_permission_preflight()
+
+    def test_busy_node_notes_and_continues(self) -> None:
+        node = fake_node("ttyACM0")
+        with mock.patch.object(INSTALLER, "_tty_nodes", return_value=[node]), \
+             mock.patch.object(INSTALLER, "_tty_is_media_tek", return_value=True), \
+             mock.patch.object(os, "geteuid", return_value=1000), \
+             mock.patch.object(os, "open", side_effect=OSError("Device or resource busy")):
+            INSTALLER.brom_permission_preflight()
+
+
+class TransportDiagnosticsTests(unittest.TestCase):
+    def test_diagnostics_never_raise(self) -> None:
+        with mock.patch.object(pathlib.Path, "glob", side_effect=OSError("no sysfs")):
+            INSTALLER._print_brom_transport_diagnostics()
+
+    def test_diagnostics_classify_known_identities(self) -> None:
+        import contextlib
+        import io
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer), \
+             mock.patch.object(INSTALLER, "_tty_nodes", return_value=[]), \
+             mock.patch.object(INSTALLER, "_running_process_names", return_value=set()), \
+             mock.patch.object(INSTALLER.pathlib.Path, "glob", return_value=iter([])):
+            INSTALLER._print_brom_transport_diagnostics()
+        self.assertIn("BROM transport diagnostics", buffer.getvalue())
+        self.assertIn("no MediaTek USB device", buffer.getvalue())
+
+
+class ProgressLoopIntegrationTests(unittest.TestCase):
+    def test_preflight_runs_before_prompt(self) -> None:
+        calls = []
+
+        def fake_preflight():
+            calls.append("preflight")
+            raise INSTALLER.InstallerError("blocked")
+
+        with mock.patch.object(INSTALLER, "brom_permission_preflight", side_effect=fake_preflight):
+            with self.assertRaises(INSTALLER.InstallerError):
+                INSTALLER.run_amonet_with_progress(
+                    pathlib.Path("/nonexistent/launcher.sh"), pathlib.Path("/tmp"), 1
+                )
+        self.assertEqual(calls, ["preflight"])
+
+    def test_stall_diagnostics_emitted_after_30s_without_progress(self) -> None:
+        import io
+        import contextlib
+
+        calls = []
+
+        class FakePopen:
+            def __init__(self, argv, cwd=None):
+                pass
+
+            def poll(self):
+                return None
+
+            def kill(self):
+                pass
+
+            def wait(self):
+                return 0
+
+        def fake_diag():
+            calls.append("diag")
+
+        clock = iter([t for t in range(0, 500)])
+
+        def fake_monotonic():
+            return next(clock)
+
+        def fake_sleep(_seconds):
+            return None
+
+        log_dir = pathlib.Path(self_tmp := __import__("tempfile").mkdtemp())
+        (log_dir / "modules").mkdir()
+        with mock.patch.object(INSTALLER.subprocess, "Popen", FakePopen), \
+             mock.patch.object(INSTALLER.time, "monotonic", fake_monotonic), \
+             mock.patch.object(INSTALLER.time, "sleep", fake_sleep), \
+             mock.patch.object(INSTALLER, "_print_brom_transport_diagnostics", side_effect=fake_diag), \
+             mock.patch.object(INSTALLER, "brom_permission_preflight"), \
+             mock.patch("builtins.print"):
+            with self.assertRaises(INSTALLER.InstallerError):
+                INSTALLER.run_amonet_with_progress(
+                    pathlib.Path("launcher.sh"), log_dir, 300
+                )
+        self.assertIn("diag", calls)
+        import shutil
+
+        shutil.rmtree(self_tmp)
+
+
+class SidecarConsistencyTests(unittest.TestCase):
+    def test_installer_exposes_preflight_symbols(self) -> None:
+        source = (ROOT / "tools" / "libreecho-install.py").read_text(encoding="utf-8")
+        self.assertIn("def brom_permission_preflight", source)
+        self.assertIn("brom_permission_preflight()", source)
+        self.assertIn("def _print_brom_transport_diagnostics", source)
+        self.assertIn("usermod -aG dialout", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Community one-shot installs hang at "waiting for BROM" when the host cannot open the MediaTek CDC node. Root cause: Amonet's shipped `serial_ports()` silently swallows `PermissionError` on every `/dev/ttyACM*` probe, so a permission-blocked port never appears as a candidate and the user sees an unexplained infinite wait. The device is connected only after the script starts, so any launch-time-only check would miss it.

## Changes

- `tools/libreecho-install.py`
  - `brom_permission_preflight()`: attempts a real `O_RDWR | O_NONBLOCK` open on each **MediaTek-vendor** `/dev/ttyACM*` node (sysfs-verified, non-MediaTek nodes ignored). On `PermissionError` it stops with an actionable message (`usermod -aG dialout $USER` + re-login, or one-shot `sudo`). Runs once at handoff start and re-runs every 5s inside the progress loop, since the port appears after the prompt. A mid-loop failure kills the Amonet child and prints transport diagnostics before raising.
  - `_print_brom_transport_diagnostics()`: on 30s without progress or launcher exit, classifies exactly what the host sees — `0e8d:0003` (BROM), `0e8d:2000/2001` (preloader, short sequence did not hold), `0e8d:2008` (AEOOT), BROM-without-tty (`cdc_acm`), ModemManager presence, and the correct short/power-on ordering remedy. Best-effort; never masks the real error.
- `tools/libreecho-install.py.sha256`: regenerated sidecar.
- `tools/test_brom_preflight.py`: 11 host-only tests — blocked/openable/non-MediaTek/busy/root/no-node preflight, diagnostics classification and non-raising, preflight-before-prompt, mid-loop invocation, 30s stall diagnostics.

## Testing and evidence

- Host/CI class only. `python3 -B -m unittest` over the full maintained aggregate (build.tests.* + tools.*, including the new module): **69 tests OK**; workflow YAML parse PASS; `git diff --check` clean.
- No image build, no deployment, and **no real-hardware execution** was performed for this change.
- Amonet's own detection fix (amonet-k32 PR #2, draft) is a separate owning-repo change; this PR fixes the Product-side silent-swallow symptom without touching the pinned Amonet commit.

Release impact: patch
Release note: One-shot installs now report exactly why the device is unreachable (permissions, preloader instead of BROM, missing cdc_acm) instead of hanging silently at "waiting for BROM".