### PR TITLE
fix(installer): make host fastboot preflight self-contained

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -186,6 +186,7 @@ jobs:
             tools.test_build_release_workflow \
             tools.test_brom_preflight \
             tools.test_initial_installer_publication \
+            tools.test_oneshot_host_preflight \
             tools.test_release_tools
       - name: Validate tracked source syntax
         run: |

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -18,6 +18,7 @@ on:
       - 'tools/run-one-shot.sh'
       - 'tools/test_initial_installer_publication.py'
       - 'tools/test_brom_preflight.py'
+      - 'tools/test_oneshot_host_preflight.py'
       - '.github/workflows/release-gate.yml'
       - '.github/workflows/publish-release.yml'
   push:
@@ -38,6 +39,7 @@ on:
       - 'tools/run-one-shot.sh'
       - 'tools/test_initial_installer_publication.py'
       - 'tools/test_brom_preflight.py'
+      - 'tools/test_oneshot_host_preflight.py'
       - '.github/workflows/release-gate.yml'
       - '.github/workflows/publish-release.yml'
   workflow_dispatch:
@@ -73,7 +75,8 @@ jobs:
             tools/test_release_tools.py \
             tools/libreecho-install.py \
             tools/test_initial_installer_publication.py \
-            tools/test_brom_preflight.py
+            tools/test_brom_preflight.py \
+            tools/test_oneshot_host_preflight.py
       - name: Reject private identifiers in public metadata
         run: python3 tools/check-public-metadata.py
       - name: Enforce full component and SBOM gate
@@ -91,3 +94,5 @@ jobs:
         run: python -B -m unittest tools.test_initial_installer_publication -v
       - name: Verify BROM permission preflight suite
         run: python -B -m unittest tools.test_brom_preflight -v
+      - name: Verify host fastboot preflight suite
+        run: python -B -m unittest tools.test_oneshot_host_preflight -v

--- a/tools/README.md
+++ b/tools/README.md
@@ -35,9 +35,19 @@ verify/download Product release
 → open the first-boot setup page
 ```
 
-The installer writes a complete console/command/ADB diagnostic log to
-`./libreecho-installer.log` by default, relative to the directory where the
-command is launched. Use `--log-file PATH` to choose another location.
+The installer also performs a host preflight before BROM. It stages a private
+copy of `fastboot` and its required `mke2fs` helper under the cache directory,
+so Ubuntu's `/usr/lib/android-sdk/platform-tools/fastboot` cannot fail merely
+because its sibling `mke2fs` is absent. The private staged tool is used for all
+fastboot operations. If `mke2fs` is not installed anywhere, the installer stops
+before device access with the exact repair command. To let it install the
+`e2fsprogs` package using `apt-get`/`sudo`, add `--install-host-deps`.
+
+Host requirements are validated before the BROM handoff:
+
+```text
+bash, adb, fastboot, executable mke2fs, staged-fastboot --version
+```
 
 It does not flash Amonet wrapper partitions directly or invent credentials. The
 Amonet exploit owns the stock-to-Amonet conversion; this tool validates the
@@ -88,6 +98,20 @@ the boxed action prompt:
 BROM entry may not work on the first attempt. If the installer continues
 waiting, power-cycle the Echo and try the short sequence again. Keep the
 terminal open and follow the live Amonet progress messages.
+
+### BROM diagnostics
+
+Transport diagnostics are shown only while the installer is actually waiting
+for BROM, or when the handoff fails before any Amonet progress is recorded. If
+`0e8d:0003` and a MediaTek `ttyACM` node are both present, the output says:
+
+```text
+BROM transport is healthy; no transport action is needed.
+```
+
+It does not print generic shorting, ModemManager, or recovery advice in that
+healthy state. Those messages are reserved for an actual missing, ambiguous, or
+incorrect transport condition.
 
 ## Resuming
 

--- a/tools/libreecho-install.py
+++ b/tools/libreecho-install.py
@@ -132,6 +132,99 @@ def require_host_commands(*commands: str) -> None:
         raise InstallerError("required host command(s) missing: " + ", ".join(missing))
 
 
+def _executable_path(command: str) -> Path:
+    resolved = shutil.which(command)
+    if resolved is None:
+        raise InstallerError(f"required host executable is missing: {command}")
+    path = Path(resolved).resolve()
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise InstallerError(f"required host executable is not runnable: {path}")
+    return path
+
+
+def _copy_executable(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(destination.name + ".part")
+    shutil.copy2(source, temporary)
+    temporary.chmod(0o755)
+    os.replace(temporary, destination)
+
+
+def _find_mke2fs(fastboot_source: Path) -> Path | None:
+    path_from_path = shutil.which("mke2fs")
+    candidates = (
+        fastboot_source.parent / "mke2fs",
+        Path(path_from_path) if path_from_path else None,
+        Path("/usr/sbin/mke2fs"),
+        Path("/usr/bin/mke2fs"),
+    )
+    for candidate in candidates:
+        if candidate is not None:
+            try:
+                candidate = candidate.resolve()
+            except OSError:
+                continue
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return candidate
+    return None
+
+
+def _install_host_e2fsprogs() -> None:
+    apt_get = shutil.which("apt-get")
+    if apt_get is None:
+        raise InstallerError(
+            "mke2fs is missing and apt-get is unavailable; install e2fsprogs manually "
+            "before starting a hardware run"
+        )
+    prefix = [] if os.geteuid() == 0 else ([shutil.which("sudo")] if shutil.which("sudo") else None)
+    if prefix is None:
+        raise InstallerError(
+            "mke2fs is missing and sudo is unavailable; install e2fsprogs manually "
+            "before starting a hardware run"
+        )
+    command_prefix = [item for item in prefix if item]
+    print("HOST PREFLIGHT: installing missing e2fsprogs (mke2fs) before device access.", flush=True)
+    _run_command(command_prefix + [apt_get, "update"], 300)
+    _run_command(command_prefix + [apt_get, "install", "-y", "e2fsprogs"], 300)
+
+
+def prepare_fastboot_tools(
+    fastboot_bin: str,
+    cache_root: Path,
+    *,
+    install_host_deps: bool = False,
+) -> str:
+    """Stage fastboot and its sibling mke2fs so format is self-contained."""
+    fastboot_source = _executable_path(fastboot_bin)
+    helper = _find_mke2fs(fastboot_source)
+    if helper is None and install_host_deps:
+        _install_host_e2fsprogs()
+        helper = _find_mke2fs(fastboot_source)
+    if helper is None:
+        raise InstallerError(
+            "HOST PREFLIGHT: mke2fs is required for fastboot format:ext4 userdata but "
+            "was not found. Re-run with --install-host-deps or install e2fsprogs "
+            "manually (for Debian/Ubuntu: sudo apt-get update && sudo apt-get install -y e2fsprogs)."
+        )
+    tool_root = cache_root / "host-tools"
+    staged_fastboot = tool_root / "fastboot"
+    staged_mke2fs = tool_root / "mke2fs"
+    _copy_executable(fastboot_source, staged_fastboot)
+    _copy_executable(helper, staged_mke2fs)
+    version = _run_command([str(staged_fastboot), "--version"], 20, check=False)
+    if version.returncode != 0:
+        raise InstallerError("HOST PREFLIGHT: staged fastboot did not run successfully")
+    mke2fs_version = _run_command([str(staged_mke2fs), "-V"], 20, check=False)
+    if mke2fs_version.returncode not in (0, 1):
+        raise InstallerError("HOST PREFLIGHT: staged mke2fs did not run successfully")
+    print(
+        f"HOST PREFLIGHT: fastboot={staged_fastboot} with mke2fs={staged_mke2fs}; "
+        "format helper ready before device access.",
+        flush=True,
+    )
+    return str(staged_fastboot)
+
+
 def _run_command(argv: list[str], timeout: float, *, check: bool = True) -> subprocess.CompletedProcess[str]:
     _append_log(f"COMMAND start timeout={timeout:g}: {argv!r}")
     try:
@@ -507,20 +600,30 @@ def _running_process_names():
     return names
 
 
+def _media_tek_usb_devices(root=None):
+    """Return {sysfs_slot: (vid, pid)} for enumerated MediaTek devices."""
+    base = pathlib.Path("/sys/bus/usb/devices") if root is None else root
+    found = {}
+    try:
+        vendor_paths = list(base.glob("*/idVendor"))
+    except OSError:
+        return found
+    for vendor_path in vendor_paths:
+        try:
+            product_path = vendor_path.with_name("idProduct")
+            vid = vendor_path.read_text(encoding="ascii").strip().lower()
+            pid = product_path.read_text(encoding="ascii").strip().lower()
+        except OSError:
+            continue
+        if vid == "0e8d":
+            found[vendor_path.parent.name] = (vid, pid)
+    return found
+
+
 def _print_brom_transport_diagnostics() -> None:
     """Classify host-side BROM transport state; best-effort, never raises."""
     try:
-        media_tek = {}
-        for vendor_path in pathlib.Path("/sys/bus/usb/devices").glob("*/idVendor"):
-            try:
-                product_path = vendor_path.with_name("idProduct")
-                media_tek[vendor_path.parent.name] = (
-                    vendor_path.read_text(encoding="ascii").strip(),
-                    product_path.read_text(encoding="ascii").strip(),
-                )
-            except OSError:
-                continue
-        mt = {slot: vidpid for slot, vidpid in media_tek.items() if vidpid[0] == "0e8d"}
+        mt = _media_tek_usb_devices()
         brom_present = any(pid == "0003" for _, pid in mt.values())
         all_nodes = [node.name for node in _tty_nodes()]
         nodes = [name for name in all_nodes if _tty_is_media_tek(pathlib.Path("/dev") / name)]
@@ -538,6 +641,10 @@ def _print_brom_transport_diagnostics() -> None:
             print(f"usb {slot}: {vid}:{pid} - {meaning}", flush=True)
         if nodes:
             print(f"MediaTek serial nodes present: {', '.join(nodes)}", flush=True)
+            if brom_present:
+                print("BROM transport is healthy; no transport action is needed.", flush=True)
+                print("--- end BROM diagnostics ---", flush=True)
+                return
         elif brom_present and unrelated:
             print(
                 "the /dev/ttyACM* nodes present ({}) are NOT MediaTek devices - "
@@ -615,7 +722,8 @@ def run_amonet_with_progress(launcher: Path, cwd: Path, timeout: float) -> None:
         returncode = process.poll()
         if returncode is not None:
             if returncode != 0:
-                _print_brom_transport_diagnostics()
+                if last_state == "Waiting for BROM/USB...":
+                    _print_brom_transport_diagnostics()
                 raise InstallerError(f"Amonet handoff failed with exit code {returncode}")
             return
         now = time.monotonic()
@@ -632,7 +740,7 @@ def run_amonet_with_progress(launcher: Path, cwd: Path, timeout: float) -> None:
                 process.wait()
                 _print_brom_transport_diagnostics()
                 raise
-        if not usb_stall_reported and now - last_notice >= 30:
+        if not usb_stall_reported and last_state == "Waiting for BROM/USB..." and now - last_notice >= 30:
             # Still at 'waiting for BROM' after 30s: classify what the host
             # actually sees so the user learns WHY, instead of staring at the
             # spinner until the 900s timeout.
@@ -1022,6 +1130,7 @@ def one_shot(
     adb_timeout: float = 180,
     open_browser: bool = True,
     execute_hardware: bool = False,
+    install_host_deps: bool = False,
     emulator_root: Path | str | None = None,
     emulator_kernel: Path | str | None = None,
     emulator_initramfs: Path | str | None = None,
@@ -1029,6 +1138,9 @@ def one_shot(
     """Run Amonet, install logical boot payloads, and open first-boot setup."""
     if not execute_hardware:
         raise InstallerError("one-shot requires --execute-hardware")
+    cache_root = Path(cache_root)
+    state_root = Path(state_root)
+    cache_root.mkdir(parents=True, exist_ok=True)
     if emulator_root is not None:
         emulator_root = Path(emulator_root)
         tool = emulator_root / "emulator_tool.py"
@@ -1040,7 +1152,9 @@ def one_shot(
         require_host_commands("bash", str(tool))
     else:
         require_host_commands("bash", fastboot_bin, adb_bin)
-    cache_root = Path(cache_root)
+        fastboot_bin = prepare_fastboot_tools(
+            fastboot_bin, cache_root, install_host_deps=install_host_deps
+        )
     state_root = Path(state_root)
     cache_root.mkdir(parents=True, exist_ok=True)
     lock_path = cache_root / ".lock"
@@ -1168,10 +1282,16 @@ def continue_one_shot(
     open_browser: bool,
     execute_hardware: bool,
     repair_userdata: bool = False,
+    install_host_deps: bool = False,
 ) -> dict[str, str]:
     if not execute_hardware:
         raise InstallerError("continuation requires --execute-hardware")
     require_host_commands("bash", fastboot_bin, adb_bin)
+    cache_root = Path(cache_root)
+    cache_root.mkdir(parents=True, exist_ok=True)
+    fastboot_bin = prepare_fastboot_tools(
+        fastboot_bin, cache_root, install_host_deps=install_host_deps
+    )
     state_path = _state_path(Path(state_root), install_id)
     state = _read_state(state_path)
     if not RELEASE.fullmatch(release_tag):
@@ -1424,6 +1544,10 @@ def main() -> None:
     parser.add_argument("--no-open-browser", action="store_true")
     parser.add_argument("--execute-hardware", action="store_true")
     parser.add_argument(
+        "--install-host-deps", action="store_true",
+        help="install missing e2fsprogs before any device operation (uses apt-get/sudo)",
+    )
+    parser.add_argument(
         "--repair-userdata", action="store_true",
         help="explicitly format userdata via fastboot when resuming an old failed run",
     )
@@ -1472,6 +1596,7 @@ def main() -> None:
                             amonet_timeout=args.amonet_timeout, fastboot_timeout=args.fastboot_timeout,
                             adb_timeout=args.adb_timeout, open_browser=not args.no_open_browser,
                             execute_hardware=args.execute_hardware or args.emulator_root is not None,
+                            install_host_deps=args.install_host_deps,
                             emulator_root=args.emulator_root,
                             emulator_kernel=args.emulator_kernel,
                             emulator_initramfs=args.emulator_initramfs,
@@ -1487,6 +1612,7 @@ def main() -> None:
                             open_browser=not args.no_open_browser,
                             execute_hardware=args.execute_hardware,
                             repair_userdata=args.repair_userdata,
+                            install_host_deps=args.install_host_deps,
                         )
                     elif args.action == "resume":
                         result = resume(args.cache_root, args.state_root, args.install_id)

--- a/tools/libreecho-install.py.sha256
+++ b/tools/libreecho-install.py.sha256
@@ -1,1 +1,1 @@
-636692b75c62837b5efa320026ee1bc4b4ccdae3c6a13c603b0647f8e05581c5  libreecho-install.py
+6fe58a82540d1841476fff04ec9761c1fccb1bc9986138bba36406fe809a4a54  libreecho-install.py

--- a/tools/test_brom_preflight.py
+++ b/tools/test_brom_preflight.py
@@ -6,6 +6,7 @@ import importlib.util
 import os
 import pathlib
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -99,6 +100,28 @@ class TransportDiagnosticsTests(unittest.TestCase):
         self.assertIn("BROM transport diagnostics", buffer.getvalue())
         self.assertIn("no MediaTek USB device", buffer.getvalue())
 
+    def test_healthy_brom_diagnostics_do_not_show_recovery_warning(self) -> None:
+        import contextlib
+        import io
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), \
+             mock.patch.object(INSTALLER, "_media_tek_usb_devices", return_value={"5-2.3": ("0e8d", "0003")}), \
+             mock.patch.object(INSTALLER, "_tty_nodes", return_value=[Path("/dev/ttyACM0")]), \
+             mock.patch.object(INSTALLER, "_tty_is_media_tek", return_value=True), \
+             mock.patch.object(INSTALLER, "_running_process_names", return_value={"ModemManager"}):
+            INSTALLER._print_brom_transport_diagnostics()
+        text = output.getvalue()
+        self.assertIn("BROM transport is healthy; no transport action is needed.", text)
+        self.assertNotIn("ModemManager is running", text)
+        self.assertNotIn("remedy if nothing helps", text)
+
+    def test_diagnostics_do_not_run_again_after_amonet_progress(self) -> None:
+        source = (ROOT / "tools/libreecho-install.py").read_text(encoding="utf-8")
+        self.assertIn(
+            'last_state == "Waiting for BROM/USB..." and now - last_notice >= 30',
+            source,
+        )
 
 class ProgressLoopIntegrationTests(unittest.TestCase):
     def test_preflight_runs_before_prompt(self) -> None:

--- a/tools/test_oneshot_host_preflight.py
+++ b/tools/test_oneshot_host_preflight.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Host fastboot dependency preflight tests."""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_installer():
+    spec = importlib.util.spec_from_file_location("libreecho_install_host_preflight", ROOT / "tools/libreecho-install.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+INSTALLER = load_installer()
+
+
+class HostFastbootPreflightTests(unittest.TestCase):
+    def test_stages_fastboot_with_mke2fs_sibling(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            staged = Path(INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary)))
+            self.assertEqual(staged, Path(temporary) / "host-tools" / "fastboot")
+            helper = staged.with_name("mke2fs")
+            self.assertTrue(staged.is_file())
+            self.assertTrue(helper.is_file())
+            self.assertTrue(staged.stat().st_mode & 0o111)
+            self.assertTrue(helper.stat().st_mode & 0o111)
+            result = subprocess.run([str(staged), "--version"], capture_output=True, text=True, check=False)
+            self.assertEqual(result.returncode, 0)
+
+    def test_missing_mke2fs_fails_before_any_device_operation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary, \
+             mock.patch.object(INSTALLER, "_find_mke2fs", return_value=None), \
+             mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as install:
+            with self.assertRaisesRegex(INSTALLER.InstallerError, "--install-host-deps"):
+                INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary))
+        install.assert_not_called()
+
+    def test_missing_dependency_install_is_opt_in(self) -> None:
+        source = (ROOT / "tools/libreecho-install.py").read_text(encoding="utf-8")
+        self.assertIn("--install-host-deps", source)
+        self.assertIn("apt-get", source)
+        result = subprocess.run(
+            ["python3", str(ROOT / "tools/libreecho-install.py"), "--help"],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--install-host-deps", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -42,6 +42,35 @@ INSTALLER = load_module("libreecho_install", ROOT / "tools/libreecho-install.py"
 
 
 class OneShotFastbootTests(unittest.TestCase):
+    def test_prepare_fastboot_tools_stages_mke2fs_sibling(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            staged = INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary))
+            staged_path = Path(staged)
+            self.assertEqual(staged_path.parent, Path(temporary) / "host-tools")
+            self.assertTrue(staged_path.is_file())
+            self.assertTrue((staged_path.parent / "mke2fs").is_file())
+            result = subprocess.run([staged, "--version"], text=True, capture_output=True, check=False)
+            self.assertEqual(result.returncode, 0)
+
+    def test_prepare_fastboot_tools_fails_before_device_when_helper_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary, \
+             mock.patch.object(INSTALLER, "_find_mke2fs", return_value=None), \
+             mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as installer:
+            with self.assertRaisesRegex(INSTALLER.InstallerError, "--install-host-deps"):
+                INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary))
+        installer.assert_not_called()
+
+    def test_prepare_fastboot_tools_can_request_missing_dependency_install(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary, \
+             mock.patch.object(INSTALLER, "_find_mke2fs", side_effect=[None, Path("/usr/sbin/mke2fs")]), \
+             mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as installer:
+            with mock.patch.object(INSTALLER, "_copy_executable") as copier, \
+                 mock.patch.object(INSTALLER, "_run_command", return_value=subprocess.CompletedProcess([], 0, "", "")):
+                staged = INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary), install_host_deps=True)
+        installer.assert_called_once_with()
+        self.assertTrue(staged.endswith("/host-tools/fastboot"))
+        self.assertEqual(copier.call_count, 2)
+
     def test_state_accepts_legacy_without_userdata_marker(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             path = Path(temporary) / "state.json"


### PR DESCRIPTION
## Summary

The physical run reached real BROM, completed Amonet, booted Linux, and then failed at the Product userdata format stage because Debian fastboot looked for its sibling helper at `/usr/lib/android-sdk/platform-tools/mke2fs`, while the host only provided `/usr/sbin/mke2fs`. The same run also printed generic ModemManager/shorting advice even though `0e8d:0003` and `ttyACM0` proved BROM transport was healthy.

## Changes

- Stage a private executable `fastboot` plus its matching `mke2fs` sibling under the cache directory before any device access; all hardware fastboot operations use the staged binary.
- Add `--install-host-deps` for an explicit apt-get/sudo installation of `e2fsprogs` when no executable `mke2fs` exists anywhere. Without the flag, stop before BROM with the exact repair command.
- Validate staged fastboot and mke2fs execution before launching Amonet.
- Print `BROM transport is healthy; no transport action is needed.` when exact BROM and its MediaTek CDC node are present; suppress generic ModemManager and shorting advice in that state.
- Emit transport diagnostics only while genuinely waiting for BROM, not during later Amonet write stages.
- Add host-tool and healthy-diagnostics regressions and wire them into the Product release gate and hosted aggregate suite.

## Testing and evidence

- Full Product host aggregate: **86 tests passed**.
- Focused host/preflight tests: **62 tests passed**.
- Python compilation: PASS.
- Workflow YAML parsing: PASS.
- `git diff --check`: PASS.
- Disposable BROM/QEMU path previously reached `WEBUI_FORWARDED` with the exact nightly; emulator mode intentionally does not use real fastboot helper staging.
- No new hardware operation was executed by this PR.

Release impact: patch
Release note: One-shot now validates and self-stages its host fastboot formatting helper before device access and no longer reports recovery warnings when BROM transport is healthy.

The existing hosted `build-image` failure from the stale upstream squashfs-tools URL is unrelated and remains separately tracked.
