### PR TITLE
test: isolate host fastboot preflight from CI tools

### DIFF
--- a/tools/test_oneshot_host_preflight.py
+++ b/tools/test_oneshot_host_preflight.py
@@ -23,11 +23,22 @@ def load_installer():
 INSTALLER = load_installer()
 
 
+def fake_executable(root: Path, name: str) -> Path:
+    path = root / name
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
+    path.chmod(0o755)
+    return path
+
+
 class HostFastbootPreflightTests(unittest.TestCase):
     def test_stages_fastboot_with_mke2fs_sibling(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
-            staged = Path(INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary)))
-            self.assertEqual(staged, Path(temporary) / "host-tools" / "fastboot")
+            root = Path(temporary)
+            fastboot = fake_executable(root, "fastboot")
+            mke2fs = fake_executable(root, "mke2fs")
+            with mock.patch.object(INSTALLER, "_find_mke2fs", return_value=mke2fs):
+                staged = Path(INSTALLER.prepare_fastboot_tools(str(fastboot), root / "cache"))
+            self.assertEqual(staged, root / "cache" / "host-tools" / "fastboot")
             helper = staged.with_name("mke2fs")
             self.assertTrue(staged.is_file())
             self.assertTrue(helper.is_file())
@@ -37,12 +48,14 @@ class HostFastbootPreflightTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0)
 
     def test_missing_mke2fs_fails_before_any_device_operation(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary, \
-             mock.patch.object(INSTALLER, "_find_mke2fs", return_value=None), \
-             mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as install:
-            with self.assertRaisesRegex(INSTALLER.InstallerError, "--install-host-deps"):
-                INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary))
-        install.assert_not_called()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fastboot = fake_executable(root, "fastboot")
+            with mock.patch.object(INSTALLER, "_find_mke2fs", return_value=None), \
+                 mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as install:
+                with self.assertRaisesRegex(INSTALLER.InstallerError, "--install-host-deps"):
+                    INSTALLER.prepare_fastboot_tools(str(fastboot), root / "cache")
+            install.assert_not_called()
 
     def test_missing_dependency_install_is_opt_in(self) -> None:
         source = (ROOT / "tools/libreecho-install.py").read_text(encoding="utf-8")

--- a/tools/test_oneshot_host_preflight.py
+++ b/tools/test_oneshot_host_preflight.py
@@ -36,8 +36,7 @@ class HostFastbootPreflightTests(unittest.TestCase):
             root = Path(temporary)
             fastboot = fake_executable(root, "fastboot")
             mke2fs = fake_executable(root, "mke2fs")
-            with mock.patch.object(INSTALLER, "_find_mke2fs", return_value=mke2fs):
-                staged = Path(INSTALLER.prepare_fastboot_tools(str(fastboot), root / "cache"))
+            staged = Path(INSTALLER.prepare_fastboot_tools(str(fastboot), root / "cache"))
             self.assertEqual(staged, root / "cache" / "host-tools" / "fastboot")
             helper = staged.with_name("mke2fs")
             self.assertTrue(staged.is_file())

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -54,8 +54,7 @@ class OneShotFastbootTests(unittest.TestCase):
             root = Path(temporary)
             fastboot = fake_executable(root, "fastboot")
             mke2fs = fake_executable(root, "mke2fs")
-            with mock.patch.object(INSTALLER, "_find_mke2fs", return_value=mke2fs):
-                staged = INSTALLER.prepare_fastboot_tools(str(fastboot), root / "cache")
+            staged = INSTALLER.prepare_fastboot_tools(str(fastboot), root / "cache")
             staged_path = Path(staged)
             self.assertEqual(staged_path.parent, root / "cache" / "host-tools")
             self.assertTrue(staged_path.is_file())

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -41,35 +41,51 @@ PUBLIC_METADATA = load_module(
 INSTALLER = load_module("libreecho_install", ROOT / "tools/libreecho-install.py")
 
 
+def fake_executable(root: Path, name: str) -> Path:
+    path = root / name
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
+    path.chmod(0o755)
+    return path
+
+
 class OneShotFastbootTests(unittest.TestCase):
     def test_prepare_fastboot_tools_stages_mke2fs_sibling(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
-            staged = INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary))
+            root = Path(temporary)
+            fastboot = fake_executable(root, "fastboot")
+            mke2fs = fake_executable(root, "mke2fs")
+            with mock.patch.object(INSTALLER, "_find_mke2fs", return_value=mke2fs):
+                staged = INSTALLER.prepare_fastboot_tools(str(fastboot), root / "cache")
             staged_path = Path(staged)
-            self.assertEqual(staged_path.parent, Path(temporary) / "host-tools")
+            self.assertEqual(staged_path.parent, root / "cache" / "host-tools")
             self.assertTrue(staged_path.is_file())
             self.assertTrue((staged_path.parent / "mke2fs").is_file())
             result = subprocess.run([staged, "--version"], text=True, capture_output=True, check=False)
             self.assertEqual(result.returncode, 0)
 
     def test_prepare_fastboot_tools_fails_before_device_when_helper_missing(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary, \
-             mock.patch.object(INSTALLER, "_find_mke2fs", return_value=None), \
-             mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as installer:
-            with self.assertRaisesRegex(INSTALLER.InstallerError, "--install-host-deps"):
-                INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary))
-        installer.assert_not_called()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fastboot = fake_executable(root, "fastboot")
+            with mock.patch.object(INSTALLER, "_find_mke2fs", return_value=None), \
+                 mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as installer:
+                with self.assertRaisesRegex(INSTALLER.InstallerError, "--install-host-deps"):
+                    INSTALLER.prepare_fastboot_tools(str(fastboot), root / "cache")
+            installer.assert_not_called()
 
     def test_prepare_fastboot_tools_can_request_missing_dependency_install(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary, \
-             mock.patch.object(INSTALLER, "_find_mke2fs", side_effect=[None, Path("/usr/sbin/mke2fs")]), \
-             mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as installer:
-            with mock.patch.object(INSTALLER, "_copy_executable") as copier, \
-                 mock.patch.object(INSTALLER, "_run_command", return_value=subprocess.CompletedProcess([], 0, "", "")):
-                staged = INSTALLER.prepare_fastboot_tools("fastboot", Path(temporary), install_host_deps=True)
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fastboot = fake_executable(root, "fastboot")
+            mke2fs = fake_executable(root, "mke2fs")
+            with mock.patch.object(INSTALLER, "_find_mke2fs", side_effect=[None, mke2fs]), \
+                 mock.patch.object(INSTALLER, "_install_host_e2fsprogs") as installer:
+                staged = INSTALLER.prepare_fastboot_tools(
+                    str(fastboot), root / "cache", install_host_deps=True
+                )
         installer.assert_called_once_with()
         self.assertTrue(staged.endswith("/host-tools/fastboot"))
-        self.assertEqual(copier.call_count, 2)
+        self.assertEqual(Path(staged).with_name("mke2fs").name, "mke2fs")
 
     def test_state_accepts_legacy_without_userdata_marker(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

PR #94 introduced host fastboot preflight tests that called `prepare_fastboot_tools("fastboot", ...)` directly. Product GitHub runners do not install Android platform-tools, so the contract and release-metadata jobs failed before testing any Product logic.

## Changes

- Replace the tests\x27 implicit dependency on a runner-installed `fastboot` with temporary executable shell fixtures.
- Keep the tests exercising executable validation, private fastboot/mke2fs staging, missing-helper fail-closed behavior, and opt-in dependency-install semantics.
- Do not change the already-fixed Ubuntu package pin or Product runtime code.

## Testing

- Full Product aggregate: 86 tests passed.
- Python compilation: PASS.
- Workflow YAML parsing: PASS.
- `git diff --check`: PASS.
- No device, fastboot, ADB, or release publication operation performed.

Release impact: none
Release note: none