### PR TITLE
fix(release): allow wildcard serial device documentation

### DIFF
--- a/tools/check-public-metadata.py
+++ b/tools/check-public-metadata.py
@@ -11,6 +11,7 @@ from pathlib import Path
 IPV4 = re.compile(r"(?<![0-9.])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9.])")
 MAC = re.compile(r"(?<![0-9A-Fa-f])(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}(?![0-9A-Fa-f])")
 RUN_ID = re.compile(r"(?<![0-9A-Za-z])20[0-9]{6}T[0-9]{6}Z(?![0-9A-Za-z])")
+PRIVATE_SERIAL_DEVICE = re.compile(r"/dev/tty(?:ACM|USB|S)[0-9]+(?:\b|$)")
 PRIVATE_NETWORKS = tuple(
     ipaddress.ip_network(value) for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 )
@@ -28,9 +29,11 @@ def violations(root: Path) -> list[str]:
             text = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        for marker in ("/home/", "/dev/tty"):
+        for marker in ("/home/",):
             if marker in text:
                 failures.append(f"{relative}: private marker {marker!r}")
+        for match in PRIVATE_SERIAL_DEVICE.finditer(text):
+            failures.append(f"{relative}: concrete serial device path {match.group(0)!r}")
         for match in RUN_ID.finditer(text):
             failures.append(f"{relative}: private run ID {match.group(0)}")
         for match in MAC.finditer(text):

--- a/tools/prepare-release.py
+++ b/tools/prepare-release.py
@@ -17,6 +17,7 @@ COMMIT = re.compile(r"^[0-9a-f]{40}$")
 EMPTY_DIFF_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 REPO = re.compile(r"^https://github\.com/[^/]+/[^/]+$")
 RUN_ID = re.compile(r"(?:^|[-_])20\d{6}T\d{6}Z(?:[-_]|$)")
+PRIVATE_SERIAL_DEVICE = re.compile(r"/dev/tty(?:ACM|USB|S)[0-9]+(?:\b|$)")
 
 
 def sha256(path: Path) -> str:
@@ -157,7 +158,7 @@ def load_components(
             value = component.get(key)
             if not isinstance(value, str) or not value:
                 failures.append(f"{component_id}: {key} is missing")
-            elif any(marker in value for marker in ("/home/", "192.168.", "/dev/tty")):
+            elif "/home/" in value or "192.168." in value or PRIVATE_SERIAL_DEVICE.search(value):
                 failures.append(f"{component_id}: {key} contains a private value")
         if scope in local_scopes or release_scope in component_release_scopes:
             applicable.append(component)

--- a/tools/test_release_tools.py
+++ b/tools/test_release_tools.py
@@ -183,6 +183,26 @@ class PublicMetadataTests(unittest.TestCase):
             )
             self.assertEqual(PUBLIC_METADATA.violations(root), [])
 
+    def test_wildcard_serial_device_documentation_is_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "installer.py").write_text(
+                "scan /dev/ttyACM* and /dev/ttyUSB*; do not use a concrete node\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(PUBLIC_METADATA.violations(root), [])
+
+    def test_concrete_serial_device_path_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "metadata.txt").write_text(
+                "captured from /dev/ttyACM0 and /dev/ttyUSB1\n",
+                encoding="utf-8",
+            )
+            failures = PUBLIC_METADATA.violations(root)
+            self.assertEqual(len(failures), 2)
+            self.assertTrue(all("concrete serial device path" in item for item in failures))
+
     def test_private_identifiers_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -220,6 +240,34 @@ class PublicMetadataTests(unittest.TestCase):
                 with self.subTest(run_id=run_id):
                     self.assertTrue(any(f"{run_id}.json" in item for item in failures))
             self.assertTrue(any("20260811T214603Z/metadata.json" in item for item in failures))
+
+    def test_prepare_release_allows_wildcard_serial_documentation(self) -> None:
+        data = json.loads((ROOT / "release/components.json").read_text())
+        audio = dict(next(c for c in data["components"] if c["id"] == "mt8163-audio-fpga"))
+        audio["download_location"] = "documented device class /dev/ttyACM*"
+        with tempfile.TemporaryDirectory() as temporary:
+            repository = Path(temporary)
+            (repository / "release").mkdir()
+            (repository / "release/THIRD_PARTY_NOTICES.md").write_text("notices\n")
+            (repository / "release/FPGA-PROVENANCE.md").write_text("documented\n")
+            catalog = repository / "release/components.json"
+            catalog.write_text(json.dumps({"schema_version": 2, "components": [audio]}))
+            self.assertEqual(PREPARE_RELEASE.load_components(catalog), [audio])
+
+    def test_prepare_release_rejects_concrete_serial_device_path(self) -> None:
+        data = json.loads((ROOT / "release/components.json").read_text())
+        audio = dict(next(c for c in data["components"] if c["id"] == "mt8163-audio-fpga"))
+        audio["download_location"] = "captured from /dev/ttyACM0"
+        with tempfile.TemporaryDirectory() as temporary:
+            repository = Path(temporary)
+            (repository / "release").mkdir()
+            (repository / "release/THIRD_PARTY_NOTICES.md").write_text("notices\n")
+            (repository / "release/FPGA-PROVENANCE.md").write_text("documented\n")
+            catalog = repository / "release/components.json"
+            catalog.write_text(json.dumps({"schema_version": 2, "components": [audio]}))
+            with self.assertRaises(SystemExit) as failure:
+                PREPARE_RELEASE.load_components(catalog)
+        self.assertIn("private value", str(failure.exception))
 
 
 class ComponentGateTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

The merged Product main publication run failed in `check-public-metadata.py` because the private-marker rule treated the legitimate wildcard documentation `/dev/ttyACM*` as a private host identifier.

## Changes

- `tools/check-public-metadata.py`: allow generic serial-device class patterns such as `/dev/ttyACM*`, while rejecting concrete paths such as `/dev/ttyACM0`, `/dev/ttyUSB1`, and `/dev/ttyS0`.
- `tools/prepare-release.py`: apply the same concrete-path rule to public component metadata instead of the broader `/dev/tty` substring check.
- `tools/test_release_tools.py`: add regressions for wildcard allowance and concrete-path rejection in both public metadata and component metadata validation.

## Evidence

The triggering Hosted Product build passed all build jobs. The dependent publisher failed only at:

```text
libreecho-...-installer.py: private marker '/dev/tty'
```

This PR addresses that false positive without weakening `/home/`, private-network, MAC, run-ID, or concrete serial-path checks.

Local verification:

- Product aggregate: 90 tests passed.
- `python3 tools/check-public-metadata.py release`: cleared.
- Python compilation: passed.
- Workflow YAML parsing: passed.
- `git diff --check`: passed.
- No device, flash, reboot, or release publication operation performed.

Release impact: patch
Release note: Release publication now accepts documented serial-device wildcard patterns while continuing to reject concrete host/device paths.
