### PR TITLE
docs(release): add 0.13.9 development identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## radar-puffin-v0.13.9
+
+See release/radar-puffin-v0.13.9.md.
+
 ## radar-puffin-v0.13.8
 
 See release/radar-puffin-v0.13.8.md.

--- a/release/radar-puffin-v0.13.9.md
+++ b/release/radar-puffin-v0.13.9.md
@@ -1,0 +1,31 @@
+# LibreEcho radar-puffin v0.13.9 development release
+
+This is a controlled **development-channel test release** for the Amazon Echo
+2nd Gen / `radar_puffin` target. It is intended for the maintainer’s test
+hardware and is not a stable or production-support commitment.
+
+## Release identity
+
+- Product release: `radar-puffin-v0.13.9`
+- OTA channel: `dev`
+- Release classification: GitHub prerelease
+- Coordinated components: Product, Platform, Linux 6.1, and UI source heads
+- Intended use: maintainer-controlled test flashing and validation
+
+The image candidate must record the exact Product, Platform, Linux, and UI
+commits used to create it. Development assets remain separate from stable
+publication and must not be marked `latest`.
+
+## Validation boundary
+
+The 0.13.9 test candidate must pass the deterministic ARM32 image build, DTB
+hardware-contract verifier, source/provenance closure, signed A/B OTA checks,
+and the relevant host-side component suites before it is flashed. A successful
+host or image build is not hardware acceptance.
+
+Physical flashing, boot, rollback, network, audio, voice, privacy, and runtime
+acceptance are separate gates. This note does not claim that those checks have
+been completed. No device is touched by the release-preparation workflow.
+
+The community-noncommercial wakeword payload and any other bundled third-party
+assets retain their individual licence and redistribution terms.


### PR DESCRIPTION
## Summary
Add the active 0.13.9 development release identity to the Product release branch. This supplies the release note and changelog index expected by the stable/release tooling without publishing or changing the current `latest` release.

## Changed files
- `release/radar-puffin-v0.13.9.md`: define the controlled dev/test release identity, channel, scope, and validation boundary.
- `CHANGELOG.md`: add the 0.13.9 release index entry.

## Validation
- `git diff --check` passed.
- The branch contains only these two release-metadata files relative to `release/0.13.9`.
- No image, runtime, hardware, publication, or flashing claim is made.

Release impact: none
Release area: release metadata
Release note: Add the controlled 0.13.9 development-release identity and validation boundary.
Validation class: documentation

This PR does not publish a release, change `latest`, or authorize hardware activity.