### PR TITLE
fix(tts): add Sherpa VITS sample-rate metadata

### DIFF
--- a/build/ci/derive-tts-model.py
+++ b/build/ci/derive-tts-model.py
@@ -8,7 +8,7 @@ model blob with ONNX ``metadata_props`` appended. The packaged artifacts are
 identified in ``tools/mt8163-arm32/tts/package_feature.sh`` (LibreEcho-Kernel)
 and in its third-party notices:
 
-  northern-male    786158f6507d49981889ece1803d8296adfcd34da847eb7e4ef69688ee148119
+  northern-male    bf4de4bc3da0ef15cd1745b4fb08ee67b9ca6bf02311ce4d2eede04a6f057411
   southern-female  cf7f487689da2ec115cb5e9b5fb5ff4450f24e0c45565e0b72dd1eb4ed4caf65
 
 Graph and tensor data are untouched; only metadata properties are appended.

--- a/build/inputs/tts-voice-metadata.json
+++ b/build/inputs/tts-voice-metadata.json
@@ -5,7 +5,7 @@
     "northern-male": {
       "upstream_file": "piper-en_GB-northern_english_male-medium.onnx",
       "output_file": "northern-male.derived.onnx",
-      "reviewed_sha256": "786158f6507d49981889ece1803d8296adfcd34da847eb7e4ef69688ee148119",
+      "reviewed_sha256": "bf4de4bc3da0ef15cd1745b4fb08ee67b9ca6bf02311ce4d2eede04a6f057411",
       "metadata_props": [
         ["model_author", "OpenSLR SLR83 contributors and Piper contributors"],
         ["model_language", "en-GB"],
@@ -13,7 +13,7 @@
         ["model_name", "northern_english_male"],
         ["model_url", "https://huggingface.co/rhasspy/piper-voices/tree/ea046e8458f6acd997706d6e6066a022b42f6fb1/en/en_GB/northern_english_male/medium"],
         ["piper_version", "1.0"],
-        ["vits_sample_rate", "22050"]
+        ["sample_rate", "22050"]
       ]
     },
     "southern-female": {

--- a/build/tests/test_public_neural_deps.py
+++ b/build/tests/test_public_neural_deps.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Contract checks for the public ARM32 neural dependency boundary."""
 from pathlib import Path
+import json
 import unittest
 
 ROOT = Path(__file__).parents[2]
@@ -51,6 +52,25 @@ class PublicNeuralDependencyTests(unittest.TestCase):
         self.assertIn('"$ESPEAK_BUILD/espeak-ng-data/phonindex"', SCRIPT)
         self.assertIn('"$ESPEAK_DATA/phontab"', SCRIPT)
         self.assertIn('"$ESPEAK_DATA/phonindex"', SCRIPT)
+
+    def test_tts_voice_metadata_uses_sherpa_sample_rate(self):
+        metadata = json.loads(
+            (ROOT / "build/inputs/tts-voice-metadata.json").read_text()
+        )
+        for name, voice in metadata["voices"].items():
+            properties = dict(voice["metadata_props"])
+            with self.subTest(voice=name):
+                self.assertIn("sample_rate", properties)
+                self.assertNotIn("vits_sample_rate", properties)
+                self.assertRegex(properties["sample_rate"], r"^[0-9]+$")
+        self.assertEqual(
+            dict(metadata["voices"]["northern-male"]["metadata_props"])["sample_rate"],
+            "22050",
+        )
+        self.assertEqual(
+            metadata["voices"]["northern-male"]["reviewed_sha256"],
+            "bf4de4bc3da0ef15cd1745b4fb08ee67b9ca6bf02311ce4d2eede04a6f057411",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary / root cause

The northern-male VITS model metadata used `vits_sample_rate`, but Sherpa-ONNX expects `sample_rate`. On the test device this caused `SherpaOnnxCreateOfflineTts` to fail and `libreecho-ttsd` to exit 255 before creating `tts.sock`.

## Changes

- Change the northern-male derivation metadata key to `sample_rate=22050`.
- Update the reviewed derived-model SHA-256 to `bf4de4bc3da0ef15cd1745b4fb08ee67b9ca6bf02311ce4d2eede04a6f057411`.
- Update derivation documentation.
- Add a regression test requiring `sample_rate`, rejecting `vits_sample_rate`, and pinning the new digest.

## Validation

- Regression test was observed RED against the old metadata: northern-male lacked `sample_rate`.
- Product TTS metadata/workflow tests: 12 passed.
- Actual derivation script reproduced both voice hashes from the pinned upstream models.
- JSON/Python syntax and `git diff --check`: passed.

## Release impact

Release impact: patch
Release area: TTS/runtime
Release note: Make the Northern English male TTS payload compatible with Sherpa-ONNX model metadata discovery.

Platform counterpart: coordinated Platform PRs update the packaging hash/notices. This is host/build evidence only; hardware runtime acceptance remains pending.
