### PR TITLE
fix(tts): use standard Sherpa Piper metadata

### DIFF
--- a/build/ci/derive-tts-model.py
+++ b/build/ci/derive-tts-model.py
@@ -8,7 +8,7 @@ model blob with ONNX ``metadata_props`` appended. The packaged artifacts are
 identified in ``tools/mt8163-arm32/tts/package_feature.sh`` (LibreEcho-Kernel)
 and in its third-party notices:
 
-  northern-male    786158f6507d49981889ece1803d8296adfcd34da847eb7e4ef69688ee148119
+  northern-male    d23e7891af7062eb188283dba94866e25ffd5b01a0d9fb9a23c71a39b75b2308
   southern-female  cf7f487689da2ec115cb5e9b5fb5ff4450f24e0c45565e0b72dd1eb4ed4caf65
 
 Graph and tensor data are untouched; only metadata properties are appended.

--- a/build/inputs/tts-voice-metadata.json
+++ b/build/inputs/tts-voice-metadata.json
@@ -5,15 +5,15 @@
     "northern-male": {
       "upstream_file": "piper-en_GB-northern_english_male-medium.onnx",
       "output_file": "northern-male.derived.onnx",
-      "reviewed_sha256": "786158f6507d49981889ece1803d8296adfcd34da847eb7e4ef69688ee148119",
+      "reviewed_sha256": "d23e7891af7062eb188283dba94866e25ffd5b01a0d9fb9a23c71a39b75b2308",
       "metadata_props": [
-        ["model_author", "OpenSLR SLR83 contributors and Piper contributors"],
-        ["model_language", "en-GB"],
-        ["model_license", "CC-BY-SA-4.0"],
-        ["model_name", "northern_english_male"],
-        ["model_url", "https://huggingface.co/rhasspy/piper-voices/tree/ea046e8458f6acd997706d6e6066a022b42f6fb1/en/en_GB/northern_english_male/medium"],
-        ["piper_version", "1.0"],
-        ["vits_sample_rate", "22050"]
+        ["model_type", "vits"],
+        ["comment", "piper"],
+        ["language", "English"],
+        ["voice", "en-gb-x-rp"],
+        ["has_espeak", "1"],
+        ["n_speakers", "1"],
+        ["sample_rate", "22050"]
       ]
     },
     "southern-female": {

--- a/build/tests/test_public_neural_deps.py
+++ b/build/tests/test_public_neural_deps.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Contract checks for the public ARM32 neural dependency boundary."""
 from pathlib import Path
+import json
 import unittest
 
 ROOT = Path(__file__).parents[2]
@@ -51,6 +52,32 @@ class PublicNeuralDependencyTests(unittest.TestCase):
         self.assertIn('"$ESPEAK_BUILD/espeak-ng-data/phonindex"', SCRIPT)
         self.assertIn('"$ESPEAK_DATA/phontab"', SCRIPT)
         self.assertIn('"$ESPEAK_DATA/phonindex"', SCRIPT)
+
+    def test_tts_voice_metadata_is_sherpa_piper_compatible(self):
+        metadata = json.loads(
+            (ROOT / "build/inputs/tts-voice-metadata.json").read_text()
+        )
+        expected = {
+            "model_type": "vits",
+            "comment": "piper",
+            "language": "English",
+            "voice": "en-gb-x-rp",
+            "has_espeak": "1",
+            "n_speakers": "1",
+            "sample_rate": "22050",
+        }
+        northern = metadata["voices"]["northern-male"]
+        self.assertEqual(dict(northern["metadata_props"]), expected)
+        self.assertEqual(
+            northern["reviewed_sha256"],
+            "d23e7891af7062eb188283dba94866e25ffd5b01a0d9fb9a23c71a39b75b2308",
+        )
+        for name, voice in metadata["voices"].items():
+            with self.subTest(voice=name):
+                properties = dict(voice["metadata_props"])
+                self.assertIn("sample_rate", properties)
+                self.assertIn("n_speakers", properties)
+                self.assertNotIn("vits_sample_rate", properties)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary / root cause

The first TTS metadata correction renamed `vits_sample_rate` to `sample_rate`, but Sherpa-ONNX also requires the standard Piper metadata fields `model_type`, `comment`, `language`, `voice`, `has_espeak`, and `n_speakers`. With only the rate correction, the Northern voice still exited during initialization before creating `tts.sock`.

## Changed files

- `build/inputs/tts-voice-metadata.json`: use the standard seven Piper/Sherpa fields and update the reviewed derived-model SHA-256.
- `build/ci/derive-tts-model.py`: update the documented reviewed digest.
- `build/tests/test_public_neural_deps.py`: require the exact Sherpa-compatible metadata and reject `vits_sample_rate`.

## Testing

- Regression test was RED against the previous metadata, identifying the missing standard fields.
- `python3 -m unittest build.tests.test_public_neural_deps tools.test_build_release_workflow`: 12 passed.
- Derivation from the pinned upstream Northern and Southern Piper models reproduced both reviewed hashes.
- JSON/Python syntax and `git diff --check`: passed.
- The standard Northern model was independently exercised on the test target and opened the private TTS socket.

This is host/source and bounded diagnostic evidence only; complete image and hardware acceptance remain separate gates.

Release impact: patch
Release note: Make the Northern English male voice load correctly in Sherpa-ONNX TTS.
