### PR TITLE
fix: bind release builds to release component refs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -132,8 +132,8 @@ jobs:
           component_ref=main
           if [[ "$GITHUB_EVENT_NAME" == pull_request && "$GITHUB_BASE_REF" == release/* ]]; then
             component_ref="$GITHUB_BASE_REF"
-          elif [[ "$RELEASE_CHANNEL" == stable ]]; then
-            component_ref="release/$RELEASE_VERSION"
+          elif [[ "$GITHUB_REF" == refs/heads/release/* ]]; then
+            component_ref="$GITHUB_REF_NAME"
           fi
           if [[ "$component_ref" != main ]]; then
             for component in LibreEcho-Platform LibreEcho-Linux-6.1 LibreEcho-UI; do

--- a/tools/test_build_release_workflow.py
+++ b/tools/test_build_release_workflow.py
@@ -310,7 +310,7 @@ class Tests(unittest.TestCase):
   self.assertIn('publish-stable:', PUBLISH)
   self.assertIn("github.event.workflow_run.event == 'workflow_dispatch'", PUBLISH)
   self.assertNotIn('aslater3/LibreEcho-Build', PUBLISH)
-  self.assertIn('component_ref="release/$RELEASE_VERSION"', W)
+  self.assertIn('component_ref="$GITHUB_REF_NAME"', W)
   self.assertIn('coordinated component ref is missing', W)
   self.assertIn('Install reviewed OTA signing dependency closure', W)
   self.assertIn('--no-index', W)
@@ -323,6 +323,13 @@ class Tests(unittest.TestCase):
   self.assertIn('UI VERSION=', W)
   self.assertIn('"$GITHUB_BASE_REF" == release/*', W)
   self.assertIn('component_ref="$GITHUB_BASE_REF"', W)
+
+ def test_release_branch_dev_uses_release_component_refs(self):
+  start = W.index('          component_ref=main')
+  end = W.index('          if [[ "$component_ref" != main ]]', start)
+  selection = W[start:end]
+  self.assertIn('elif [[ "$GITHUB_REF" == refs/heads/release/* ]]; then', selection)
+  self.assertIn('component_ref="$GITHUB_REF_NAME"', selection)
 
  def test_release_gate_triggers_cover_gate_inputs(self):
   # Files consumed by the release gate must trigger it when changed directly;


### PR DESCRIPTION
## Summary / root cause
Release-branch development builds resolved Platform, Linux, and UI from `main` unless the run was a stable dispatch. That allowed a `release/0.13.9` Product source to produce a mixed-source candidate. Release branches must consume their matching coordinated component refs.

## Changed files
- `.github/workflows/build-release.yml`: select `GITHUB_REF_NAME` for release-branch push/dispatch builds and retain the release-branch PR behavior.
- `tools/test_build_release_workflow.py`: regression coverage for release-branch component-ref selection.

## Testing and evidence
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tools.test_build_release_workflow` — 10 tests passed.
- `python3 -m py_compile tools/test_build_release_workflow.py` — passed.
- `git diff --check` — passed.
- Tested commit: `5816c866a933bf2b6d489932d0a56ee432e211fd`.

This is host/workflow evidence only; it does not claim image, device, or hardware acceptance.

Release impact: patch
Release area: build / OTA provenance
Release note: none (internal release-safety correction)
Validation class: host / CI

Refs #20