### PR TITLE
docs(release): prepare 0.13.11 button backport candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## radar-puffin-v0.13.11 (UNRELEASED)
+
+See [the 0.13.11 release note](release/radar-puffin-v0.13.11.md).
+
+## radar-puffin-v0.13.10
+
+See [the 0.13.10 release note](release/radar-puffin-v0.13.10.md).
+
 ## radar-puffin-v0.13.9
 
 See release/radar-puffin-v0.13.9.md.

--- a/release/radar-puffin-v0.13.11.md
+++ b/release/radar-puffin-v0.13.11.md
@@ -1,0 +1,115 @@
+# LibreEcho radar-puffin v0.13.11
+
+**Status: UNRELEASED candidate.** This Product metadata records a proposed
+0.13.11 patch release for the Amazon Echo 2nd Gen (`radar_puffin`, ARMv7,
+Linux 6.1). It is based on the 0.13.10 release line and is intended to carry
+the narrowly selected physical-button backport from the 0.14 development work.
+It is not a published release, installation recommendation, build result, CI
+result, or hardware-acceptance record.
+
+## Release identity and source boundary
+
+- Product release ID: `radar-puffin-v0.13.11`
+- Product version: `0.13.11`
+- Candidate state: `UNRELEASED`
+- Release impact: `patch`
+- Backport base: `release/0.13.10`
+- Product base identity before this metadata: `66ad65e86d298c55ee10ddebbafc152c74128274`
+- Published 0.13.10 baseline source map (provenance only, not 0.13.11
+  candidate heads): Product `66ad65e86d298c55ee10ddebbafc152c74128274`,
+  Platform `a265f2ee36b9af8fb0591c97c19b4c67b009a45a`, Linux 6.1
+  `b110727cdd3dec6ef20c4d28889c63239f0a8ec3`, and UI
+  `1d38b3b3318739143171104945c48939edc35bde`.
+- Source policy: backport only the selected button functionality; do not merge
+  unrelated `main` or `0.14` changes.
+- Coordinated Product, Platform, Linux 6.1, and UI source heads must be
+  recorded as exact immutable commits before any stable build or publication.
+
+The matching `release/0.13.11` refs and machine-readable UI version are
+coordination gates, not assumptions made by this note. The Product workflow
+must resolve the exact four-repository source set from the release refs and
+fail closed if a component ref is missing or the UI `VERSION` is not
+`0.13.11`.
+
+## Candidate scope
+
+This candidate is limited to the physical-button behavior required for the
+0.13.11 backport, together with the independently owned Platform, Linux, UI,
+and final-device-tree changes needed to close that behavior:
+
+- physical button input and mute/privacy behavior, including the selected
+  button daemon and LED/audio feedback integration. The final design must keep
+  one owner for the hardware privacy latch, synchronize software mute state,
+  preserve mute state across startup, and avoid clearing a preserved hardware
+  privacy state with a startup indicator;
+- the implemented action-sound feedback path, which rotates through the
+  available action sounds. Existing `audiod` cue functionality is preserved;
+  this backport must not import unrelated 0.14 regressions; and
+- the corresponding PMIC mute, `GPIO36` / `KEY_HELP`, privacy-workqueue,
+  packaging, sound, and final-DTB work owned by the component repositories.
+
+The action-sound rotation must not be described as a general action-mapping
+settings system. Independent listen/play-pause action selection and
+short-press versus long-press action settings are **not implemented by this
+candidate**. Legacy compatibility fields may remain, but release notes,
+UI controls, API documentation and tests must not present them as working
+actions.
+
+No unrelated 0.14 feature, moving `main` head, or broad release-branch merge
+belongs in this patch candidate. Component changes remain owned and reviewed
+in their respective repositories; Product carries only release-facing metadata
+and orchestration for this source set.
+
+## Validation boundary and remaining gates
+
+No build, hosted CI run, signed artifact, device deployment, reboot, physical
+button test, or hardware runtime acceptance is claimed by this UNRELEASED note.
+Any mute-state or startup-preservation check performed during this metadata task
+is only a host/source validation boundary; preservation of the hardware privacy
+latch remains unconfirmed until the separately authorized device test.
+Before publication, the coordinating release work still requires all of the
+following:
+
+1. Create and verify matching `release/0.13.11` refs in Product, Platform,
+   Linux 6.1, and UI through the normal pull-request flow; record their exact
+   tested heads and prove that none comes from an unrelated `main`/`0.14`
+   merge.
+2. Confirm UI `VERSION=0.13.11`, Product release-note identity, release branch,
+   workflow `release_version`, and candidate manifest agree.
+3. Close the button behavior across UI/API, daemon, init/service packaging,
+   Platform sounds and final DTB, Linux PMIC mute, `GPIO36` / `KEY_HELP`, and
+   privacy-workqueue paths. Compile/source checks do not prove packaged or
+   runtime behavior.
+4. Run the Product metadata, component, installer/public-input, workflow
+   contract, and release-packaging checks, followed by the exact hosted Product
+   candidate build and independent image/provenance verification.
+5. Confirm the candidate manifest and `release-source-commits.txt` bind the
+   exact Product, Platform, Linux, and UI commits; preserve
+   `PREPARED_NOT_FLASHED` until a separately authorized deployment decision.
+6. Exercise physical button, mute/privacy, LED, action-sound rotation, boot,
+   rollback, and service-readiness behavior on authorized hardware. Treat
+   listen/play-pause mapping and short/long action settings as out of scope,
+   not as failed acceptance criteria for this release.
+7. Only after the preceding gates pass may a maintainer perform the separate
+   stable workflow dispatch, signing/publication, release-asset checksum
+   verification, and any later hardware-acceptance process.
+
+## Installation and publication
+
+There are no 0.13.11 downloads or installation instructions while this note is
+`UNRELEASED`. Do not use this candidate identity as a stable tag, `latest`
+asset, OTA source, or hardware-test artifact. When authorized publication is
+later performed, users must use only the generated release assets and matching
+`SHA256SUMS`; publication still does not by itself establish physical-device
+runtime acceptance.
+
+## License and distribution boundary
+
+The eventual release remains subject to the repository's public component
+allowlist and the individual notices for bundled components. In particular,
+the community-noncommercial wakeword payload retains its
+**CC-BY-NC-SA-4.0** noncommercial, attribution, modification-notice, and
+ShareAlike requirements, while TTS voice assets retain their separate
+**CC-BY-SA-4.0** obligations. No credentials, signing material, device
+identifiers, owner-local connectivity firmware, or private build metadata
+belongs in public release metadata.

--- a/release/radar-puffin-v0.13.11.md
+++ b/release/radar-puffin-v0.13.11.md
@@ -1,115 +1,57 @@
 # LibreEcho radar-puffin v0.13.11
 
-**Status: UNRELEASED candidate.** This Product metadata records a proposed
-0.13.11 patch release for the Amazon Echo 2nd Gen (`radar_puffin`, ARMv7,
-Linux 6.1). It is based on the 0.13.10 release line and is intended to carry
-the narrowly selected physical-button backport from the 0.14 development work.
-It is not a published release, installation recommendation, build result, CI
-result, or hardware-acceptance record.
+LibreEcho 0.13.11 is a focused physical-button backport for the Amazon Echo
+2nd Gen (`radar_puffin`, ARMv7, Linux 6.1), based on the published 0.13.10
+source set. It excludes unrelated 0.14 development changes.
 
-## Release identity and source boundary
+## Button fixes
+
+- Package and start the button daemon and its init service so physical input
+  reaches the audio and LED services.
+- Restore volume up/down handling and feedback.
+- Synchronize physical mute with the kernel-owned privacy latch without a
+  second userspace toggle; preserve hardware privacy state during startup.
+- Map the action button on `GPIO36` to `KEY_HELP` and provide rotating bundled
+  action sounds with LED feedback.
+- Persist button preferences, restore them at startup and configuration import,
+  and retain mute-ring feedback across temporary effects and LED-service restarts.
+- Include the matching PMIC input, privacy-workqueue, device-tree, packaging,
+  sound assets, and independent image-verification changes.
+
+Action feedback supports sound rotation or disabling the action. General
+listen/play-pause mappings and separate short/long-press actions are not
+implemented; legacy compatibility fields do not enable those actions.
+
+## Source and validation policy
 
 - Product release ID: `radar-puffin-v0.13.11`
 - Product version: `0.13.11`
-- Candidate state: `UNRELEASED`
 - Release impact: `patch`
-- Backport base: `release/0.13.10`
-- Product base identity before this metadata: `66ad65e86d298c55ee10ddebbafc152c74128274`
-- Published 0.13.10 baseline source map (provenance only, not 0.13.11
-  candidate heads): Product `66ad65e86d298c55ee10ddebbafc152c74128274`,
-  Platform `a265f2ee36b9af8fb0591c97c19b4c67b009a45a`, Linux 6.1
-  `b110727cdd3dec6ef20c4d28889c63239f0a8ec3`, and UI
-  `1d38b3b3318739143171104945c48939edc35bde`.
-- Source policy: backport only the selected button functionality; do not merge
-  unrelated `main` or `0.14` changes.
-- Coordinated Product, Platform, Linux 6.1, and UI source heads must be
-  recorded as exact immutable commits before any stable build or publication.
+- Baseline: published 0.13.10 source set, not moving `main`.
+- Product, Platform, Linux, and UI use coordinated `release/0.13.11` refs.
+  The hosted build must record their exact commits in the candidate manifest
+  and `release-source-commits.txt`; UI `VERSION` must equal `0.13.11`.
 
-The matching `release/0.13.11` refs and machine-readable UI version are
-coordination gates, not assumptions made by this note. The Product workflow
-must resolve the exact four-repository source set from the release refs and
-fail closed if a component ref is missing or the UI `VERSION` is not
-`0.13.11`.
+Merging source is not publication or proof of hardware behavior. Publication
+requires component checks, the canonical hosted Product build, independent
+image/provenance verification, and separately authorized physical-button,
+privacy, boot, rollback, and service-readiness acceptance. Release coordination
+and acceptance evidence are tracked in Product issue #134 rather than as
+transient status assertions in these reusable release notes.
 
-## Candidate scope
+## Installation and verification
 
-This candidate is limited to the physical-button behavior required for the
-0.13.11 backport, together with the independently owned Platform, Linux, UI,
-and final-device-tree changes needed to close that behavior:
-
-- physical button input and mute/privacy behavior, including the selected
-  button daemon and LED/audio feedback integration. The final design must keep
-  one owner for the hardware privacy latch, synchronize software mute state,
-  preserve mute state across startup, and avoid clearing a preserved hardware
-  privacy state with a startup indicator;
-- the implemented action-sound feedback path, which rotates through the
-  available action sounds. Existing `audiod` cue functionality is preserved;
-  this backport must not import unrelated 0.14 regressions; and
-- the corresponding PMIC mute, `GPIO36` / `KEY_HELP`, privacy-workqueue,
-  packaging, sound, and final-DTB work owned by the component repositories.
-
-The action-sound rotation must not be described as a general action-mapping
-settings system. Independent listen/play-pause action selection and
-short-press versus long-press action settings are **not implemented by this
-candidate**. Legacy compatibility fields may remain, but release notes,
-UI controls, API documentation and tests must not present them as working
-actions.
-
-No unrelated 0.14 feature, moving `main` head, or broad release-branch merge
-belongs in this patch candidate. Component changes remain owned and reviewed
-in their respective repositories; Product carries only release-facing metadata
-and orchestration for this source set.
-
-## Validation boundary and remaining gates
-
-No build, hosted CI run, signed artifact, device deployment, reboot, physical
-button test, or hardware runtime acceptance is claimed by this UNRELEASED note.
-Any mute-state or startup-preservation check performed during this metadata task
-is only a host/source validation boundary; preservation of the hardware privacy
-latch remains unconfirmed until the separately authorized device test.
-Before publication, the coordinating release work still requires all of the
-following:
-
-1. Create and verify matching `release/0.13.11` refs in Product, Platform,
-   Linux 6.1, and UI through the normal pull-request flow; record their exact
-   tested heads and prove that none comes from an unrelated `main`/`0.14`
-   merge.
-2. Confirm UI `VERSION=0.13.11`, Product release-note identity, release branch,
-   workflow `release_version`, and candidate manifest agree.
-3. Close the button behavior across UI/API, daemon, init/service packaging,
-   Platform sounds and final DTB, Linux PMIC mute, `GPIO36` / `KEY_HELP`, and
-   privacy-workqueue paths. Compile/source checks do not prove packaged or
-   runtime behavior.
-4. Run the Product metadata, component, installer/public-input, workflow
-   contract, and release-packaging checks, followed by the exact hosted Product
-   candidate build and independent image/provenance verification.
-5. Confirm the candidate manifest and `release-source-commits.txt` bind the
-   exact Product, Platform, Linux, and UI commits; preserve
-   `PREPARED_NOT_FLASHED` until a separately authorized deployment decision.
-6. Exercise physical button, mute/privacy, LED, action-sound rotation, boot,
-   rollback, and service-readiness behavior on authorized hardware. Treat
-   listen/play-pause mapping and short/long action settings as out of scope,
-   not as failed acceptance criteria for this release.
-7. Only after the preceding gates pass may a maintainer perform the separate
-   stable workflow dispatch, signing/publication, release-asset checksum
-   verification, and any later hardware-acceptance process.
-
-## Installation and publication
-
-There are no 0.13.11 downloads or installation instructions while this note is
-`UNRELEASED`. Do not use this candidate identity as a stable tag, `latest`
-asset, OTA source, or hardware-test artifact. When authorized publication is
-later performed, users must use only the generated release assets and matching
-`SHA256SUMS`; publication still does not by itself establish physical-device
-runtime acceptance.
+Use only assets attached to the matching published Product release and verify
+them against its `SHA256SUMS`. A branch name or source note alone is not an
+installable artifact or authorization to install, reboot, or publish.
 
 ## License and distribution boundary
 
-The eventual release remains subject to the repository's public component
-allowlist and the individual notices for bundled components. In particular,
-the community-noncommercial wakeword payload retains its
+Distribution remains subject to the public component allowlist and individual
+component notices. The community-noncommercial wakeword payload retains its
 **CC-BY-NC-SA-4.0** noncommercial, attribution, modification-notice, and
-ShareAlike requirements, while TTS voice assets retain their separate
-**CC-BY-SA-4.0** obligations. No credentials, signing material, device
-identifiers, owner-local connectivity firmware, or private build metadata
-belongs in public release metadata.
+ShareAlike requirements. TTS voice assets retain their separate
+**CC-BY-SA-4.0** obligations. Action sound attribution is retained in the UI
+sound provenance notices. Credentials, signing material, device identifiers,
+owner-local connectivity firmware, and private build metadata are excluded
+from public release metadata.


### PR DESCRIPTION
## Summary
Prepare the authored **UNRELEASED 0.13.11** patch-release note for the physical-button functionality backport from 0.14.0 onto the exact published 0.13.10 source set.

Root cause tracked by this release: the old image omitted the button daemon; additional key mapping, privacy, action feedback and sound-asset packaging changes require coordinated component backports.

## Changed files
- `release/radar-puffin-v0.13.11.md`: candidate identity, scope, published baseline provenance and remaining validation gates.
- `CHANGELOG.md`: link the new candidate and preceding 0.13.10 release notes.

## Testing
Run on this branch after the final metadata edit:
- `python3 -B -m unittest -v build.tests.test_generate_release_notes tools.test_build_release_workflow tools.test_release_tools` — **49 passed**.
- `python3 tools/check-public-metadata.py` — **cleared**.
- `git diff --check` — **passed**.

These are host/source metadata checks, not image or hardware acceptance. The document intentionally makes no publication, deployment or runtime-success claim. Existing legacy action-setting fields may remain for compatibility but must not be presented as implemented listening/play-pause/short-long behavior.

## Coordination
Tracks https://github.com/aslater3/LibreEcho/issues/134 . Component PR links will be added as their local validation completes. All PRs target `release/0.13.11`; no unrelated 0.14/main merge is intended.

Release impact: patch

Release note: Prepare LibreEcho 0.13.11 to restore physical button functionality and feedback on the 0.13 release line.

**Do not merge or publish without explicit owner approval.**
