### PR TITLE
docs: align agent operating contract with Astra guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,52 +6,64 @@ cross-repository public documentation, release notes, and release tooling. Read
 
 ## Agent operating contract
 
-These rules take priority over the procedural sections below for normal task
-execution.
+These rules govern normal task execution, subject to higher-priority system and
+developer instructions and the repository/workspace safety boundaries below.
 
-1. The user's current request defines the scope. Work only on the named problem
-   and the files needed to solve it. Do not fix adjacent bugs, refactor nearby
-   code, clean up unrelated issues, or improve the architecture unless asked.
+1. The user's current request defines the intended scope. A request to fix,
+   implement, or update explicitly authorizes reversible local preparation in
+   that scope: create or use a purpose-named branch/worktree, investigate the
+   necessary in-scope files, make the required edits, create local commits, and
+   run appropriate validation. Do not stop merely because the work needs more
+   in-scope files than first expected; expected file count is not a boundary.
 
-2. Before editing, identify:
-   - the requested outcome;
-   - the files likely to change;
-   - the smallest relevant validation command.
-   Do not begin a broader investigation without explaining why it is necessary.
+2. Work only on the named problem and the files needed to solve it. Do not fix
+   adjacent bugs, refactor nearby code, clean up unrelated issues, or improve
+   the architecture unless asked. Preserve unrelated dirty changes and other
+   worktrees; do not reset, stash, clean, switch, delete, or absorb them merely
+   to make the requested task convenient.
 
-3. Make the smallest change that satisfies the request. Do not expand the task
-   because you notice a possible improvement or a failure in another subsystem.
+3. Before editing, identify the requested outcome, likely files, and validation
+   needed to establish it. Ask before a material scope expansion, destructive or
+   irreversible operation, or unresolved decision; first complete independent
+   authorized work that does not depend on that decision.
 
-4. Stop when the requested acceptance criterion is met. A successful focused
-   test is a stopping point, not an invitation to search for more work.
+4. Reviews, diagnoses, explanations, and plans do not authorize project-file
+   edits unless the user explicitly asks for edits. Publication, push, pull
+   request creation, merge, release/tagging, deployment, flashing, rebooting,
+   and other hardware-changing actions remain separate explicit gates.
 
-5. Run one relevant, bounded, focused host check by default. Do not run the
-   aggregate suite, full image builds, release workflows, CI polling, hardware
-   validation, flashing, rebooting, watchers, servers, or background processes
-   unless the user explicitly requests that operation.
+5. Every command must have a bounded timeout. Bounded background work,
+   watchers, or servers are permitted only when needed for the authorized
+   outcome; define their scope and timeout, capture their result, and stop and
+   clean them up on completion or timeout. Do not retry indefinitely.
 
-6. Every command must have a bounded timeout. If a command hangs, exceeds its
-   timeout, or begins doing work outside the request, stop it and report the
-   command and observed state. Do not retry indefinitely.
+6. Run focused, meaningful checks that establish every acceptance criterion and
+   all applicable repository-required checks. Do not impose a one-test limit or
+   a blanket aggregate-suite requirement: broaden or repeat validation when
+   changed paths, failures, required checks, or unresolved risk justify it. If
+   authorized PR publication is part of the workflow, required CI must complete
+   and be green on the exact head; otherwise do not poll remote CI unprompted.
+   Keep host, CI, image/release, and hardware evidence distinct. Stop when every
+   acceptance criterion is evidenced and required checks pass. Report unrelated
+   failures and whether they block acceptance; do not fix them silently. Avoid
+   tests that merely mirror reversible, low-impact implementation details.
 
-7. If a test or check fails outside the requested scope, do not fix it as part of
-   the current task. Report the exact failure and whether it blocks the
-   requested acceptance criterion.
+7. Subject to higher-priority system/developer instructions and explicit
+   project safety boundaries, the current request takes precedence over
+   procedural defaults in skills or later non-safety guidance. If an instruction
+   blocks completion, identify its exact source file and section, quote the
+   exact blocking rule, explain the conflict, and complete independent
+   authorized work rather than silently abandoning it.
 
-8. If the work would touch another repository, another subsystem, more files
-   than originally expected, or a second unrelated root cause, stop and ask
-   before expanding scope.
+8. Delegate independent, bounded research, review, or test analysis when tools
+   support it and delegation improves speed or quality. Give each delegate
+   disjoint write ownership or read-only work; never permit shared writes, and
+   verify delegated findings before reporting success. Do not require recursive
+   delegation when the harness does not support it.
 
-9. Do not create or switch branches, commit, push, open a pull request, merge,
-   tag, wait for CI, or perform hardware actions unless the user explicitly
-   requests that specific action.
-
-10. The branching, pull-request, CI, release, and versioning sections below
-    apply when the user requests those workflows. They do not create permission
-    to perform them automatically.
-
-11. If the user asks only for a review, diagnosis, explanation, or plan, do not
-    edit files. Return findings and proposed changes instead.
+9. Use concise plain language. Give brief progress updates during long tasks;
+   report results first, with exact evidence and remaining blockers at a
+   proportionate level of detail.
 
 # Branching, Pull Requests, and Versioning
 
@@ -187,10 +199,10 @@ prefixes require maintainer agreement.
   directly applicable `CONTRIBUTING.md`; do not recursively inspect unrelated
   documentation or historical source.
 - Re-read the live branch, status, and diff before making changes.
-- Work only in a purpose-named branch when an edit has been explicitly
-  requested and the current branch is appropriate for that task.
-- Run the smallest relevant focused check first. Broader validation is
-  conditional on the user's request or explicit PR preparation.
+- For an authorized edit, create or use an isolated purpose-named branch
+  based on the current base selected by the branch policy above.
+- Run meaningful focused checks and all applicable required checks under
+  the operating contract above; broaden only when justified.
 - Report exact commands and results. Do not claim image, CI, or hardware
   evidence when only host-source checks were run.
 - Record the exact commit SHA that was tested; the PR head must equal the


### PR DESCRIPTION
## Summary
Align the repository agent operating contract with the Astra guidance while preserving the repository-specific ownership and release rules.

## Changed files
- `AGENTS.md` — update the shared agent operating contract and its validation/branching guidance.

## Testing and evidence
- `git diff --check origin/main...HEAD` — passed.
- `git diff --name-only origin/main...HEAD` — `AGENTS.md` only.
- Documentation-only change; no source, build, image, or real-hardware validation was performed.
- The PR is based on `main`, the appropriate default for this documentation-only change; no release branch is being changed.

Release impact: none
Release note: none

Coordinated AGENTS.md-only PRs:
- LibreEcho: https://github.com/aslater3/LibreEcho/pull/137
- LibreEcho-Platform: https://github.com/aslater3/LibreEcho-Platform/pull/122
- LibreEcho-UI: https://github.com/aslater3/LibreEcho-UI/pull/220
- LibreEcho-Linux-6.1: https://github.com/aslater3/LibreEcho-Linux-6.1/pull/28