### PR TITLE
fix(ota): stage v2 public key before handoff

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -2223,6 +2223,10 @@ ota_bundle_sha=
 if [[ "$OTA_FORMAT" == v2 ]]; then
   ota_base_catalog_copy="$RUN/ota-base-catalog.json"
   cp -- "$OTA_BASE_CATALOG" "$ota_base_catalog_copy"
+  # The v2 handoff validates and records the run-local public key before the
+  # protected signer runs.  The workflow also copies this key after the build
+  # for artifact publication, but that is too late for create-handoff.
+  install -m 0644 "$OTA_PUBLIC_KEY" "$RUN/ota-public-key.hex"
   python3 -B "$PIPELINE/ci/sign_ota_candidate.py" create-handoff \
     --run-dir "$RUN" --release "$OTA_RELEASE" --source-commit "$ui_commit" \
     --update-channel "$UPDATE_CHANNEL" --base-catalog "$ota_base_catalog_copy" \

--- a/build/tests/test_plan_feature_transaction.py
+++ b/build/tests/test_plan_feature_transaction.py
@@ -243,6 +243,13 @@ class FeaturePlanTests(unittest.TestCase):
         self.assertIn('--platform-tool "$OTA_DIR/make_ota_bundle.py"', build)
         self.assertIn("LIBREECHO_OTA_BASE_CATALOG", build)
 
+    def test_v2_stages_run_local_public_key_before_handoff(self) -> None:
+        build = (SCRIPT.parents[1] / "build.sh").read_text()
+        key_stage = 'install -m 0644 "$OTA_PUBLIC_KEY" "$RUN/ota-public-key.hex"'
+        handoff = 'python3 -B "$PIPELINE/ci/sign_ota_candidate.py" create-handoff'
+        self.assertIn(key_stage, build)
+        self.assertLess(build.index(key_stage), build.index(handoff))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary / root cause
The merged OTA v2 hosted build creates its protected signing handoff before the workflow's later artifact-public-key copy step. `sign_ota_candidate.py create-handoff` therefore rejects the missing run-local `ota-public-key.hex` and the v2 build stops before signing.

## Changes
- Stage the Platform public key into the run directory immediately before v2 handoff creation.
- Add a regression assertion that the staging command precedes `create-handoff` while preserving the v1 default.

## Testing and evidence
- `python3 -B -m unittest -v build.tests.test_plan_feature_transaction` (7 passed)
- `bash -n build/build.sh`
- `git diff --check`
- Hosted failure: Product run `34089350809`, exact merged Product head `2f49162e2c5ca3c3aaea1532cc6449e7fd0cc69a`; failure was `artifact is not a regular file: .../ota-public-key.hex` during the v2 handoff.

Release impact: patch
Release note: none

This fixes the Product-owned hosted v2 candidate path only. It does not alter signing secrets, stable publication, or hardware behavior.
