### PR TITLE
fix: support explicit dev device OTA baselines

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -51,6 +51,10 @@ on:
         default: v1
         type: choice
         options: [v1, v2]
+      device_baseline_json:
+        description: Optional hash-only dev device migration baseline (manual v2 only)
+        required: false
+        type: string
       ota_release:
         description: OTA v2 candidate version (defaults to release branch version)
         required: false
@@ -97,11 +101,18 @@ jobs:
           SSH_ENABLED_INPUT: ${{ inputs.ssh_enabled || 'disabled' }}
           OTA_FORMAT_INPUT: ${{ inputs.ota_format || 'v1' }}
           OTA_RELEASE_INPUT: ${{ inputs.ota_release || (inputs.ota_format == 'v2' && inputs.release_version) || '' }}
+          DEVICE_BASELINE_JSON: ${{ inputs.device_baseline_json || '' }}
           OTA_BASE_CATALOG_URL_INPUT: ''
           OTA_BASE_CATALOG_SHA256_INPUT: ''
           SIGNING_MODE: ${{ github.event_name == 'pull_request' && 'github' || 'local' }}
         run: |
           set -euo pipefail
+          if [[ -n "$DEVICE_BASELINE_JSON" ]]; then
+            [[ "$GITHUB_EVENT_NAME" == workflow_dispatch && "$RELEASE_CHANNEL" == dev && "$OTA_FORMAT_INPUT" == v2 && "$GITHUB_REF" == refs/heads/release/0.13.11 ]] || {
+              echo "ERROR: device migration requires manual dev v2 release/0.13.11 dispatch" >&2; exit 1;
+            }
+            UPDATE_CHANNEL="$RELEASE_CHANNEL" python3 -c 'import os,sys; sys.path.insert(0,"build/ci"); from device_baseline import parse; parse(os.environ["DEVICE_BASELINE_JSON"], os.environ["UPDATE_CHANNEL"])'
+          fi
           if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
             case "$GITHUB_BASE_REF" in
               main|release/*) ;;
@@ -250,6 +261,7 @@ jobs:
             build.tests.test_component_cache \
             build.tests.test_prepare_dev_release \
             build.tests.test_fetch_ota_base \
+            build.tests.test_device_baseline \
             build.tests.test_ota_v2_signing \
             build.tests.test_ota_v2_complete_gate \
             build.tests.test_public_inputs \
@@ -949,10 +961,17 @@ jobs:
         if: needs.resolve-and-preflight.outputs.ota_format == 'v2'
         env:
           OTA_RELEASE: ${{ needs.resolve-and-preflight.outputs.ota_release }}
+          DEVICE_BASELINE_JSON: ${{ inputs.device_baseline_json || '' }}
+          UPDATE_CHANNEL: ${{ inputs.update_channel || 'dev' }}
+          OTA_FORMAT: ${{ inputs.ota_format || 'v1' }}
         run: |
           set -euo pipefail
-          python3 build/ci/fetch-ota-base.py --release "$OTA_RELEASE" \
-            --output-dir "$RUNNER_TEMP/ota-base" --github-output "$GITHUB_OUTPUT"
+          if [[ -n "$DEVICE_BASELINE_JSON" ]]; then
+            python3 build/ci/device_baseline.py
+          else
+            python3 build/ci/fetch-ota-base.py --release "$OTA_RELEASE" \
+              --output-dir "$RUNNER_TEMP/ota-base" --github-output "$GITHUB_OUTPUT"
+          fi
 
       - name: Build image and features
         env:

--- a/build/build.sh
+++ b/build/build.sh
@@ -2205,6 +2205,7 @@ for offset in range(0, len(args), 3):
 output_path.write_text(json.dumps({"features": features}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 PY
   planner_args=(
+    --update-channel "$UPDATE_CHANNEL"
     --base-catalog "$OTA_BASE_CATALOG"
     --candidate-catalog "$feature_candidate_catalog"
     --release "$OTA_RELEASE"

--- a/build/ci/DEV-DEVICE-MIGRATION.md
+++ b/build/ci/DEV-DEVICE-MIGRATION.md
@@ -1,0 +1,41 @@
+# Development-device OTA v2 migration
+
+The normal OTA v2 build derives its baseline from the preceding stable release.
+A boot-only bridge does not change installed feature payloads. Development
+payloads can therefore differ from the public baseline and correctly fail a
+preserve check.
+
+For explicitly authorized development migration only, manual Hosted build
+supports `device_baseline_json` on `release/0.13.11`, with `update_channel=dev`
+and `ota_format=v2`. Other combinations fail before build. Leaving the input
+empty retains the release-derived baseline and v1 defaults unchanged.
+
+Input is bounded to 8192 UTF-8 bytes and has exactly this schema:
+
+- `schema`: `libreecho-dev-device-baseline-v1`
+- `features`: exactly `airplay2`, `tts`, `wakeword`, `stt`, `assistant`
+- Each feature: exactly `payload_sha256`, `manifest_sha256`, `daemon_sha256`,
+  each a lowercase SHA-256 hex string.
+
+Capture payload and manifest bytes read-only, verify hashes on the device before
+and after transfer, and verify the daemon bytes inside each captured SquashFS
+against the feature manifest. This is maintainer-supplied device identity, **not
+proof of a published or trusted release**. Never put serials, paths, settings,
+credentials or arbitrary file content in this input. Duplicate and extra keys
+are rejected. Preserve a private local evidence record of capture verification.
+
+The planner uses verified CI candidate bytes, replaces changed supported
+features, and preserves the actual Wakeword generation because Wakeword is
+excluded from this system-update policy. Runtime capsules are forbidden in
+this migration mode. The protected signer checks the hash-bound baseline again
+against every feature's base identity and all preserved daemon identities;
+stable signing rejects this schema. The device's existing signed manifest,
+preserve hash, staging, boot readback and rollback checks are not bypassed.
+
+A successful host plan is not permission to install. Before deployment, verify
+the signed package, exact boot image and all replacement assets, asset delivery
+availability, target baseline stability, and storage headroom. Manual control-tar
+upload alone does not transfer external feature assets. Keep the confirmed
+rollback slot. Record reboot, exact image identity, service acceptance and
+changed-feature acceptance separately. No wipe or ad-hoc updater replacement
+is required or authorized by this input.

--- a/build/ci/device_baseline.py
+++ b/build/ci/device_baseline.py
@@ -1,0 +1,78 @@
+"""Explicit maintainer-supplied dev migration identities, not release provenance.
+
+The target must still verify every preserved byte; this input never authorizes
+runtime capsules, stable signing, or publishing a release from device data.
+"""
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+
+SCHEMA = 'libreecho-dev-device-baseline-v1'
+FEATURES = ('airplay2', 'tts', 'wakeword', 'stt', 'assistant')
+FIELDS = {'payload_sha256', 'manifest_sha256', 'daemon_sha256'}
+MAX_BYTES = 8192
+
+
+def pairs(items):
+    result = {}
+    for key, value in items:
+        if key in result:
+            raise ValueError('duplicate baseline key')
+        result[key] = value
+    return result
+
+
+def parse(text, channel):
+    if channel != 'dev':
+        raise ValueError('device baseline requires dev channel')
+    if len(text.encode('utf-8')) > MAX_BYTES:
+        raise ValueError('device baseline exceeds limit')
+    data = json.loads(text, object_pairs_hook=pairs)
+    if not isinstance(data, dict) or set(data) != {'schema', 'features'} or data['schema'] != SCHEMA:
+        raise ValueError('device baseline schema mismatch')
+    features = data['features']
+    if not isinstance(features, dict) or set(features) != set(FEATURES):
+        raise ValueError('device baseline requires all five features')
+    for record in features.values():
+        if not isinstance(record, dict) or set(record) != FIELDS:
+            raise ValueError('device baseline record mismatch')
+        for value in record.values():
+            if not isinstance(value, str) or re.fullmatch('[0-9a-f]{64}', value) is None:
+                raise ValueError('device baseline hash malformed')
+    return data
+
+
+def validate_plan(data, plan):
+    records = plan['features']
+    if len(records) != len(FEATURES) or {r['feature_id'] for r in records} != set(FEATURES):
+        raise ValueError('device migration feature set mismatch')
+    for record in records:
+        base = data['features'][record['feature_id']]
+        if (record['base_payload_sha256'] != base['payload_sha256'] or
+                record['base_manifest_sha256'] != base['manifest_sha256']):
+            raise ValueError('device migration baseline binding mismatch')
+        if record['action'] not in {'preserve', 'replace'}:
+            raise ValueError('device migration forbids runtime capsules')
+        if record['action'] == 'preserve' and record['daemon_sha256'] != base['daemon_sha256']:
+            raise ValueError('device migration preserved daemon mismatch')
+        if record['feature_id'] == 'wakeword' and record['action'] != 'preserve':
+            raise ValueError('device migration must preserve wakeword')
+
+
+def main():
+    text = os.environ['DEVICE_BASELINE_JSON']
+    if os.environ.get('GITHUB_EVENT_NAME') != 'workflow_dispatch' or os.environ.get('OTA_FORMAT') != 'v2':
+        raise ValueError('device baseline requires manual v2 dispatch')
+    data = parse(text, os.environ['UPDATE_CHANNEL'])
+    path = Path(os.environ['RUNNER_TEMP']) / 'device-baseline.json'
+    encoded = (json.dumps(data, sort_keys=True, separators=(',', ':')) + '\n').encode()
+    with path.open('xb') as stream:
+        stream.write(encoded)
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as stream:
+        stream.write(f'catalog={path}\nsha256={hashlib.sha256(encoded).hexdigest()}\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/build/ci/plan-feature-transaction.py
+++ b/build/ci/plan-feature-transaction.py
@@ -131,6 +131,7 @@ def runtime_record(path: Path, feature: str, base: dict[str, Any], candidate: di
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--update-channel", choices=("dev", "stable"), default="stable")
     parser.add_argument("--base-catalog", type=Path, required=True)
     parser.add_argument("--candidate-catalog", type=Path, required=True)
     parser.add_argument("--runtime-dir", type=Path)
@@ -146,7 +147,23 @@ def main() -> int:
             fail("release must be numeric SemVer")
         if COMMIT40.fullmatch(args.source_commit) is None:
             fail("source commit is malformed")
-        base, candidate = strict_catalog(args.base_catalog), strict_catalog(args.candidate_catalog)
+        from device_baseline import SCHEMA as DEVICE_SCHEMA, parse as parse_device, validate_plan as validate_device_plan
+        candidate = strict_catalog(args.candidate_catalog)
+        raw_base = load_json(args.base_catalog, "base catalog")
+        device = None
+        if isinstance(raw_base, dict) and raw_base.get("schema") == DEVICE_SCHEMA:
+            device = parse_device(args.base_catalog.read_text(), args.update_channel)
+            if args.runtime_dir:
+                fail("device migration forbids runtime capsules")
+            base = {fid: {
+                "payload": {"sha256": r["payload_sha256"]},
+                "manifest": {"sha256": r["manifest_sha256"]},
+                "files": {DAEMONS[fid]: {"sha256": r["daemon_sha256"]}},
+            } for fid, r in device["features"].items()}
+            # Excluded wakeword keeps the observed device generation, not CI's.
+            candidate["wakeword"] = base["wakeword"]
+        else:
+            base = strict_catalog(args.base_catalog)
         if args.runtime_dir and args.runtime_dir.is_symlink():
             fail("runtime directory must not be a symlink")
         records: list[dict[str, Any]] = []
@@ -184,6 +201,8 @@ def main() -> int:
                 ])
         plan = {"schema": "libreecho-product-feature-plan-v1", "transaction_type": "system", "activation": "reboot", "release": args.release, "source_commit": args.source_commit, "features": records}
         validate_plan(plan, args.release, args.source_commit)
+        if device is not None:
+            validate_device_plan(device, plan)
         if args.asset_output_dir:
             if args.asset_output_dir.exists():
                 fail("OTA asset output directory already exists")

--- a/build/ci/sign_ota_candidate.py
+++ b/build/ci/sign_ota_candidate.py
@@ -334,6 +334,12 @@ def validate_handoff(path: Path, expected_release: str = EXPECTED_RELEASE) -> di
     if not isinstance(data["base_catalog_sha256"], str) or len(data["base_catalog_sha256"]) != 64 or any(c not in "0123456789abcdef" for c in data["base_catalog_sha256"]):
         raise HandoffError("signing handoff base catalog hash is malformed")
     base_catalog = _check_record(data["base_catalog"], "base catalog")
+    from device_baseline import SCHEMA as DEVICE_SCHEMA, parse as parse_device, validate_plan as validate_device_plan
+    baseline_data = json.loads(base_catalog.read_text())
+    if isinstance(baseline_data, dict) and baseline_data.get("schema") == DEVICE_SCHEMA:
+        device = parse_device(base_catalog.read_text(), data["update_channel"])
+        plan_path = _check_record(data["feature_plan"], "feature plan")
+        validate_device_plan(device, json.loads(plan_path.read_text()))
     if data["base_catalog"]["sha256"] != data["base_catalog_sha256"]:
         raise HandoffError("signing handoff base catalog identity mismatch")
     if not isinstance(data["run_dir"], str):

--- a/build/tests/test_device_baseline.py
+++ b/build/tests/test_device_baseline.py
@@ -1,0 +1,87 @@
+"""Dev-only identity override gates and actual planner regression."""
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'ci'))
+import device_baseline as device
+from build.tests.test_plan_feature_transaction import write_catalog, run_plan, COMMIT
+
+
+class DeviceBaselineTests(unittest.TestCase):
+    def baseline(self):
+        return {'schema': device.SCHEMA, 'features': {
+            f: {k: 'a' * 64 for k in device.FIELDS} for f in device.FEATURES}}
+
+    def test_strict_schema_and_dev_channel(self):
+        data = self.baseline()
+        self.assertEqual(device.parse(json.dumps(data), 'dev'), data)
+        invalid = [dict(data, serial='private'), dict(data, schema='unknown')]
+        missing = copy.deepcopy(data)
+        del missing['features']['tts']
+        invalid.append(missing)
+        bad = copy.deepcopy(data)
+        bad['features']['tts']['payload_sha256'] = 'A' * 64
+        invalid.append(bad)
+        for value in invalid:
+            with self.assertRaises(ValueError):
+                device.parse(json.dumps(value), 'dev')
+        for text, channel in [(json.dumps(data), 'stable'), (' ' * 8193, 'dev'),
+                              ('{"schema":1,"schema":2}', 'dev')]:
+            with self.assertRaises(ValueError):
+                device.parse(text, channel)
+
+    def test_workflow_guard_rejects_non_dev_non_v2_and_nonmanual(self):
+        import os
+        import subprocess
+        import textwrap
+        root = Path(__file__).resolve().parents[2]
+        workflow = (root / '.github/workflows/build-release.yml').read_text()
+        block = workflow.split('      - id: resolve', 1)[1].split('        run: |', 1)[1]
+        guard = textwrap.dedent(block.split('          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then', 1)[0])
+        env = dict(os.environ, DEVICE_BASELINE_JSON=json.dumps(self.baseline()),
+                   GITHUB_EVENT_NAME='workflow_dispatch', RELEASE_CHANNEL='dev',
+                   OTA_FORMAT_INPUT='v2', GITHUB_REF='refs/heads/release/0.13.11')
+        self.assertEqual(subprocess.run(['bash', '-c', guard], env=env, cwd=root, capture_output=True, timeout=10).returncode, 0)
+        for key, value in [('RELEASE_CHANNEL', 'stable'), ('OTA_FORMAT_INPUT', 'v1'),
+                           ('GITHUB_EVENT_NAME', 'push'), ('GITHUB_REF', 'refs/heads/main'),
+                           ('DEVICE_BASELINE_JSON', '{"serial":"private"}')]:
+            result = subprocess.run(['bash', '-c', guard], env=env | {key: value}, cwd=root, capture_output=True, timeout=10)
+            self.assertNotEqual(result.returncode, 0, key)
+        self.assertIn('build.tests.test_device_baseline', workflow)
+
+    def test_real_planner_preserves_excluded_wakeword(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            candidate = write_catalog(root, 'candidate')
+            base = root / 'device.json'
+            base.write_text(json.dumps(self.baseline()))
+            output = root / 'plan.json'
+            args = ['--base-catalog', str(base), '--candidate-catalog', str(candidate),
+                    '--release', '0.13.11', '--source-commit', COMMIT, '--output', str(output)]
+            rejected = run_plan(*args)
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertFalse(output.exists())
+            accepted = run_plan(*args, '--update-channel', 'dev')
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            plan = json.loads(output.read_text())
+            device.validate_plan(self.baseline(), plan)
+            self.assertEqual({r['feature_id']: r['action'] for r in plan['features']},
+                             {f: 'preserve' if f == 'wakeword' else 'replace' for f in device.FEATURES})
+            for mutate in ('base', 'daemon', 'runtime', 'wakeword'):
+                altered = copy.deepcopy(plan)
+                record = next(r for r in altered['features'] if r['feature_id'] == 'wakeword')
+                if mutate == 'base': record['base_payload_sha256'] = 'b' * 64
+                if mutate == 'daemon': record['daemon_sha256'] = 'b' * 64
+                if mutate == 'runtime': record['action'] = 'runtime'
+                if mutate == 'wakeword': record['action'] = 'replace'
+                with self.assertRaises(ValueError): device.validate_plan(self.baseline(), altered)
+            runtime = run_plan(*args, '--update-channel', 'dev', '--runtime-dir', str(root))
+            self.assertNotEqual(runtime.returncode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Fix development-device OTA v2 preparation when installed feature identities differ from the published baseline. A boot-only bridge does not reconcile feature payloads; preserve validation correctly rejects the old all-preserve plan.

Add an explicit hash-only baseline input for manual dev/v2 dispatch on release/0.13.11. Normal release-derived baselines and v1 defaults remain unchanged. No device data or measured device hashes are committed.

## Changed files
- `.github/workflows/build-release.yml`: guarded optional input, baseline selection, maintained regression wiring.
- `build/build.sh`: pass the actual channel to the planner.
- `build/ci/device_baseline.py`: bounded exact schema and baseline-to-plan validation.
- `build/ci/plan-feature-transaction.py`: dev migration planning with excluded Wakeword preserved and runtime capsules prohibited.
- `build/ci/sign_ota_candidate.py`: revalidate migration identities at the protected signing handoff.
- `build/tests/test_device_baseline.py`: schema, executed workflow guard, and actual planner regressions.
- `build/ci/DEV-DEVICE-MIGRATION.md`: operator contract and evidence boundaries.

## Verification
- Pinned Python environment: workflow-listed unittest modules, **55 tests, OK**.
- `bash -n build/build.sh` and `git diff --check`: passed.
- Captured-device host fixture: original signed package fails `preserve-payload-mismatch`; explicit migration prepares successfully. Ephemeral host-fixture signing only, not production signing.
- Hash-only baseline produces the identical plan as the verified full-file catalog: TTS/STT replace, AirPlay/Assistant/Wakeword preserve.
- Canonical payload daemon hashes independently verified against captured SquashFS bytes.

## Remaining gates
Hosted CI and required review; protected migration signing; replacement-asset delivery; device preflight and installation; reboot/active image/feature acceptance. No device writes, flashing, reboot, stable publication, private signing-key access or updater bypass in this change.

Release impact: none
Release note: none (unreleased development migration tooling)
