### PR TITLE
fix: publish all-preserve v2 artifacts without empty directories

### DIFF
--- a/build/ci/ota_v2_product.py
+++ b/build/ci/ota_v2_product.py
@@ -232,15 +232,19 @@ def load_feature_contract(run: Path, candidate: dict[str, str]) -> tuple[dict[st
     if not isinstance(asset_dir_value, str) or Path(asset_dir_value).name != "ota-assets":
         fail("candidate has an invalid feature_asset_dir")
     asset_dir = run / "ota-assets"
-    if asset_dir.is_symlink() or not asset_dir.is_dir():
-        fail("candidate is missing ota-assets")
+    if asset_dir.is_symlink() or (asset_dir.exists() and not asset_dir.is_dir()):
+        fail("candidate has an unsafe ota-assets path")
 
     plan = load_json(plan_path, "feature plan")
     records = validate_plan(plan, release, source_commit)
     inventory = load_json(inventory_path, "feature asset inventory")
     assets = validate_inventory(inventory, records, release)
     expected_names = {item["name"] for item in assets}
-    entries = list(asset_dir.iterdir())
+    # Artifact transport omits empty directories. Only an independently
+    # validated empty plan/inventory may omit this directory.
+    if not asset_dir.exists() and expected_names:
+        fail("candidate is missing ota-assets")
+    entries = list(asset_dir.iterdir()) if asset_dir.exists() else []
     if any(entry.is_symlink() or not entry.is_file() for entry in entries):
         fail("feature asset directory contains an unsafe entry")
     if {entry.name for entry in entries} != expected_names:
@@ -425,7 +429,9 @@ def _bind_control_to_feature_contract(
     expected_assets.sort(key=lambda item: item["name"])
     if assets != expected_assets:
         fail("signed control feature records do not match feature-assets.json")
-    if asset_dir.is_symlink() or not asset_dir.is_dir():
+    if (asset_dir.is_symlink()
+            or (asset_dir.exists() and not asset_dir.is_dir())
+            or (assets and not asset_dir.is_dir())):
         fail("feature asset directory is unavailable")
     for item in assets:
         actual_hash, actual_size = digest(asset_dir / item["name"])

--- a/build/tests/test_prepare_dev_release.py
+++ b/build/tests/test_prepare_dev_release.py
@@ -186,6 +186,46 @@ def add_v2_contract(run: Path, commits: dict[str, str], release: str = "0.13.11"
 
 
 class Tests(unittest.TestCase):
+    def test_signed_all_preserve_publication_without_empty_asset_directory(self):
+        import shutil
+        for shape in ('missing', 'symlink', 'file'):
+            with self.subTest(shape=shape), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                run, commits = fixture(root)
+                add_v2_contract(run, commits)
+                plan_path = run / 'feature-plan.json'
+                plan = json.loads(plan_path.read_text())
+                for record in plan['features']:
+                    record['action'] = 'preserve'
+                    for key in ('asset', 'size', 'sha256', 'manifest_asset', 'manifest_size', 'manifest_sha256'):
+                        record.pop(key, None)
+                plan_path.write_text(json.dumps(plan))
+                inventory_path = run / 'feature-assets.json'
+                inventory = json.loads(inventory_path.read_text())
+                inventory['assets'] = []
+                inventory_path.write_text(json.dumps(inventory))
+                ota = run / 'development.ota.tar'
+                make_signed_ota(run, ota, '0.13.11', 'v2', plan_path)
+                candidate = run / 'CURRENT.candidate'
+                text = candidate.read_text().replace('ota_signing_mode=github\n', 'ota_signing_mode=local\n')
+                text = text.replace('ota_bundle=\n', 'ota_bundle=' + str(ota) + '\n')
+                text = text.replace('ota_bundle_sha256=\n', 'ota_bundle_sha256=' + digest(ota) + '\n')
+                candidate.write_text(text)
+                shutil.rmtree(run / 'ota-assets')
+                if shape == 'symlink':
+                    (run / 'ota-assets').symlink_to(root / 'absent')
+                elif shape == 'file':
+                    (run / 'ota-assets').write_text('not a directory')
+                result = subprocess.run([
+                    sys.executable, str(SCRIPT), '--artifact-root', str(root),
+                    '--output-dir', str(root / 'release'), '--product-commit', commits['product'],
+                ], env={**os.environ, 'LIBREECHO_OTA_EXPECTED_PUBLIC_KEY_SHA256': digest(run / 'ota-public-key.hex')}, capture_output=True, text=True, timeout=30)
+                if shape == 'missing':
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertTrue(list((root / 'release').glob('*.ota.tar')))
+                else:
+                    self.assertNotEqual(result.returncode, 0)
+
     def test_prepares_v2_external_assets_without_renaming_them(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary
Artifact transport omits empty directories, causing valid all-preserve v2 publication to fail. Accept an absent asset directory only after validating empty plan/inventory and signed control binding. Symlinks, regular-file substitutions, and missing required assets remain rejected.

## Files
- build/ci/ota_v2_product.py: handle absent empty directories at both validation boundaries.
- build/tests/test_prepare_dev_release.py: signed full-preparation regression with omitted directory and unsafe substitutions.

## Verification
20 preparation/signing tests passed. Exact previously failed signed CI artifact successfully prepared locally with 20 release assets. No remote publication or device mutation performed by this change.

Release impact: patch
Release note: Allow boot-only v2 development updates to publish when no external feature assets are required.