### PR TITLE
fix: provision stable publisher verification dependencies

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -245,6 +245,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.artifact.outputs.name }}
           path: verified-build
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: '3.11'
+      - name: Install reviewed OTA verification dependencies
+        run: |
+          set -euo pipefail
+          wheelhouse="$GITHUB_WORKSPACE/build/inputs/reviewed/python-wheels"
+          python -m pip install --disable-pip-version-check --no-index \
+            --find-links "$wheelhouse" --require-hashes \
+            --requirement "$wheelhouse/requirements.txt"
       - name: Read stable release request
         id: request
         run: |
@@ -293,6 +303,7 @@ jobs:
           PLATFORM_HEAD: ${{ steps.sources.outputs.platform_head }}
           LINUX_HEAD: ${{ steps.sources.outputs.linux_head }}
           UI_HEAD: ${{ steps.sources.outputs.ui_head }}
+          LIBREECHO_OTA_EXPECTED_PUBLIC_KEY_SHA256: ${{ vars.LIBREECHO_OTA_EXPECTED_PUBLIC_KEY_SHA256 }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
@@ -318,6 +329,7 @@ jobs:
       - name: Publish stable Product release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIBREECHO_OTA_EXPECTED_PUBLIC_KEY_SHA256: ${{ vars.LIBREECHO_OTA_EXPECTED_PUBLIC_KEY_SHA256 }}
           RELEASE_TAG: ${{ steps.request.outputs.release_tag }}
           RELEASE_DIR: release-assets
           RELEASE_NOTES: ${{ steps.request.outputs.release_notes }}

--- a/tools/test_build_release_workflow.py
+++ b/tools/test_build_release_workflow.py
@@ -264,6 +264,39 @@ class Tests(unittest.TestCase):
   self.assertIn('--tree "reviewed-connectivity=$PIPELINE/inputs/reviewed/connectivity"', B)
   # The vendored path must not invoke the musl toolchain rebuild anymore.
   self.assertNotIn('build_connectivity_helpers.sh', B)
+ def test_stable_publisher_installs_reviewed_verifier_closure(self):
+  import os, subprocess, tempfile, textwrap, venv
+  stable = PUBLISH.split('  publish-stable:', 1)[1]
+  self.assertEqual(stable.count('LIBREECHO_OTA_EXPECTED_PUBLIC_KEY_SHA256: ${{ vars.LIBREECHO_OTA_EXPECTED_PUBLIC_KEY_SHA256 }}'), 2)
+  marker = '      - name: Install reviewed OTA verification dependencies'
+  self.assertIn(marker, stable)
+  self.assertIn("python-version: '3.11'", stable)
+  self.assertLess(stable.index('actions/setup-python@'), stable.index(marker))
+  self.assertLess(stable.index(marker), stable.index('Prepare signed stable release assets'))
+  step = stable.split(marker, 1)[1].split('\n      - ', 1)[0]
+  script = textwrap.dedent(step.split('        run: |\n', 1)[1])
+  for guard in ('--no-index', '--require-hashes',
+                '--find-links "$wheelhouse"', '--requirement "$wheelhouse/requirements.txt"'):
+   self.assertIn(guard, script)
+  # Replay the shipped step in an isolated interpreter with no ambient PyNaCl.
+  with tempfile.TemporaryDirectory() as directory:
+   envroot = Path(directory)/'venv'
+   venv.EnvBuilder(with_pip=True).create(envroot)
+   env = dict(os.environ, PATH=str(envroot/'bin')+os.pathsep+os.environ['PATH'],
+              GITHUB_WORKSPACE=str(ROOT.resolve()), PYTHONNOUSERSITE='1')
+   env.pop('PYTHONPATH', None)
+   before = subprocess.run([str(envroot/'bin/python'), '-c', 'import nacl'],
+                           env=env, capture_output=True, timeout=10)
+   self.assertNotEqual(before.returncode, 0)
+   installed = subprocess.run(['bash', '-c', script], env=env, cwd=ROOT,
+                              capture_output=True, text=True, timeout=90)
+   self.assertEqual(installed.returncode, 0, installed.stdout+installed.stderr)
+   verified = subprocess.run([str(envroot/'bin/python'), '-c',
+       'from nacl.signing import SigningKey; k=SigningKey.generate(); '
+       'assert k.verify_key.verify(k.sign(b"test fixture")) == b"test fixture"'],
+       env=env, capture_output=True, text=True, timeout=10)
+   self.assertEqual(verified.returncode, 0, verified.stderr)
+
  def test_reviewed_signing_dependencies_are_downloaded_before_install(self):
   build_image = W.index('  build-image:')
   download = W.index('name: public-deps-${{ needs.resolve-and-preflight.outputs.source_set_id }}', build_image)


### PR DESCRIPTION
## Summary / root cause
The default-branch workflow_run stable publisher runs exact release-branch Product code but did not provision its Python 3.11/PyNaCl verifier closure or pass the trusted public-key digest to both stable consumers. Dev publication already provisions the reviewed closure. This activates the stable publisher on the default branch; a matching release-branch PR keeps the source definition aligned.

## Files
- `.github/workflows/publish-release.yml`: install the existing reviewed, offline, hash-pinned dependency closure before stable preparation; pass the configured trusted public-key digest to preparation and publication.
- `tools/test_build_release_workflow.py`: replay the actual workflow dependency step in a clean virtualenv, prove PyNaCl was absent, and perform a fixture signature verification after installation; assert ordering and both trust-anchor settings.

## Verification
`python3 tools/test_build_release_workflow.py` — 11 tests passed. New regression failed before the fix. `git diff --check` passed.
No private signing key, stable publication, target installation, or hardware acceptance was involved. Hosted CI is pending; not yet merge-ready. Normal approving review is required.

Release impact: none
Release note: none
Related: #134
