### PR TITLE
fix: allow explicit dev wakeword baseline normalization

### DIFF
--- a/build/ci/device_baseline.py
+++ b/build/ci/device_baseline.py
@@ -2,6 +2,9 @@
 
 The target must still verify every preserved byte; this input never authorizes
 runtime capsules, stable signing, or publishing a release from device data.
+Wakeword remains preserved unless the hash-bound JSON explicitly includes
+``"replace_wakeword": true`` to adopt the validated Product candidate payload.
+Omit the field to retain the previous behavior; strings and false are rejected.
 """
 import hashlib
 import json
@@ -30,8 +33,11 @@ def parse(text, channel):
     if len(text.encode('utf-8')) > MAX_BYTES:
         raise ValueError('device baseline exceeds limit')
     data = json.loads(text, object_pairs_hook=pairs)
-    if not isinstance(data, dict) or set(data) != {'schema', 'features'} or data['schema'] != SCHEMA:
+    allowed_keys = ({'schema', 'features'}, {'schema', 'features', 'replace_wakeword'})
+    if not isinstance(data, dict) or set(data) not in allowed_keys or data['schema'] != SCHEMA:
         raise ValueError('device baseline schema mismatch')
+    if 'replace_wakeword' in data and data['replace_wakeword'] is not True:
+        raise ValueError('replace_wakeword must be the explicit boolean true')
     features = data['features']
     if not isinstance(features, dict) or set(features) != set(FEATURES):
         raise ValueError('device baseline requires all five features')
@@ -57,8 +63,9 @@ def validate_plan(data, plan):
             raise ValueError('device migration forbids runtime capsules')
         if record['action'] == 'preserve' and record['daemon_sha256'] != base['daemon_sha256']:
             raise ValueError('device migration preserved daemon mismatch')
-        if record['feature_id'] == 'wakeword' and record['action'] != 'preserve':
-            raise ValueError('device migration must preserve wakeword')
+        if (record['feature_id'] == 'wakeword' and record['action'] != 'preserve'
+                and data.get('replace_wakeword') is not True):
+            raise ValueError('device migration must preserve wakeword without explicit opt-in')
 
 
 def main():

--- a/build/ci/plan-feature-transaction.py
+++ b/build/ci/plan-feature-transaction.py
@@ -160,8 +160,9 @@ def main() -> int:
                 "manifest": {"sha256": r["manifest_sha256"]},
                 "files": {DAEMONS[fid]: {"sha256": r["daemon_sha256"]}},
             } for fid, r in device["features"].items()}
-            # Excluded wakeword keeps the observed device generation, not CI's.
-            candidate["wakeword"] = base["wakeword"]
+            # Keep the observed wakeword unless the hash-bound dev input opts in.
+            if device.get("replace_wakeword") is not True:
+                candidate["wakeword"] = base["wakeword"]
         else:
             base = strict_catalog(args.base_catalog)
         if args.runtime_dir and args.runtime_dir.is_symlink():

--- a/build/tests/test_device_baseline.py
+++ b/build/tests/test_device_baseline.py
@@ -53,6 +53,65 @@ class DeviceBaselineTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0, key)
         self.assertIn('build.tests.test_device_baseline', workflow)
 
+    def test_explicit_wakeword_replacement_is_strict_and_dev_only(self):
+        data = dict(self.baseline(), replace_wakeword=True)
+        self.assertEqual(device.parse(json.dumps(data), 'dev'), data)
+        with self.assertRaises(ValueError):
+            device.parse(json.dumps(data), 'stable')
+        for value in (False, 0, 1, 'true', None, [], {}):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                device.parse(json.dumps(dict(data, replace_wakeword=value)), 'dev')
+
+    def test_real_planner_stages_only_explicit_wakeword_replacement(self):
+        from build.tests.test_plan_feature_transaction import DAEMONS, digest
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            candidate = write_catalog(root, 'candidate')
+            catalog = json.loads(candidate.read_text())['features']
+            baseline = self.baseline()
+            for fid, entry in catalog.items():
+                manifest = json.loads(Path(entry['manifest']['path']).read_text())
+                baseline['features'][fid] = {
+                    'payload_sha256': entry['payload']['sha256'],
+                    'manifest_sha256': entry['manifest']['sha256'],
+                    'daemon_sha256': manifest['files'][DAEMONS[fid]]['sha256'],
+                }
+            baseline['features']['wakeword'] = {k: 'a' * 64 for k in device.FIELDS}
+            baseline['replace_wakeword'] = True
+            base = root / 'device.json'
+            base.write_text(json.dumps(baseline))
+            output, assets = root / 'plan.json', root / 'ota-assets'
+            args = ['--base-catalog', str(base), '--candidate-catalog', str(candidate),
+                    '--release', '0.13.11', '--source-commit', COMMIT,
+                    '--output', str(output), '--asset-output-dir', str(assets)]
+            rejected = run_plan(*args, '--update-channel', 'stable')
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertFalse(output.exists())
+            self.assertFalse(assets.exists())
+            accepted = run_plan(*args, '--update-channel', 'dev')
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            plan = json.loads(output.read_text())
+            device.validate_plan(baseline, plan)
+            self.assertEqual({r['feature_id']: r['action'] for r in plan['features']},
+                             {f: 'replace' if f == 'wakeword' else 'preserve' for f in device.FEATURES})
+            wake = next(r for r in plan['features'] if r['feature_id'] == 'wakeword')
+            self.assertEqual({p.name for p in assets.iterdir()}, {wake['asset'], wake['manifest_asset']})
+            for name, key in ((wake['asset'], 'sha256'), (wake['manifest_asset'], 'manifest_sha256')):
+                self.assertEqual(digest(assets / name), wake[key])
+            for flag in (False, True):
+                altered = copy.deepcopy(plan)
+                record = next(r for r in altered['features'] if r['feature_id'] == 'wakeword')
+                if flag:
+                    record['base_payload_sha256'] = 'b' * 64
+                else:
+                    record['action'] = 'runtime'
+                with self.assertRaises(ValueError):
+                    device.validate_plan(baseline, altered)
+            without_opt_in = copy.deepcopy(baseline)
+            del without_opt_in['replace_wakeword']
+            with self.assertRaises(ValueError):
+                device.validate_plan(without_opt_in, plan)
+
     def test_real_planner_preserves_excluded_wakeword(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)


### PR DESCRIPTION
## Summary / root cause
The maintainer-only dev migration path always preserves wakeword, so a development device with a different wakeword generation cannot be normalized to the published feature baseline before a normal stable update.

Add the explicit optional JSON field `"replace_wakeword": true`. The field is validated and included in the hashed baseline consumed again at signing. Omission retains the previous preserve behavior. Stable, runtime-capsule, malformed/unknown field, base-hash, signature, and public-key trust gates are not relaxed.

## Files
- `build/ci/device_baseline.py`: parse/document the strict opt-in and permit a validated replacement plan only with opt-in.
- `build/ci/plan-feature-transaction.py`: select the validated Product wakeword candidate only when opted in.
- `build/tests/test_device_baseline.py`: strict boolean/dev-only tests, real planner asset-byte checks, four-preserve/one-replace fixture, and rejection of unauthorized/runtime/base-hash mutations.

## Verification
`LIBREECHO_PLATFORM_SRC=<absolute Platform checkout> python3 -m unittest build.tests.test_device_baseline build.tests.test_ota_v2_signing build.tests.test_prepare_dev_release -q` — 25 tests passed, no skips. New normalization regression failed before the fix. `git diff --check` passed.
This includes host fixture signing with an ephemeral test key, not release signing or live OTA. The target has not been changed. Hosted CI and approving review remain required.

Release impact: none
Release note: none
Related: #134

Companion: https://github.com/aslater3/LibreEcho/pull/144
