### PR TITLE
fix: prepare Product 0.13.13 OTA release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -108,8 +108,8 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -n "$DEVICE_BASELINE_JSON" ]]; then
-            [[ "$GITHUB_EVENT_NAME" == workflow_dispatch && "$RELEASE_CHANNEL" == dev && "$OTA_FORMAT_INPUT" == v2 && "$GITHUB_REF" == refs/heads/release/0.13.12 ]] || {
-              echo "ERROR: device migration requires manual dev v2 release/0.13.12 dispatch" >&2; exit 1;
+            [[ "$GITHUB_EVENT_NAME" == workflow_dispatch && "$RELEASE_CHANNEL" == dev && "$OTA_FORMAT_INPUT" == v2 && "$GITHUB_REF" == refs/heads/release/0.13.13 ]] || {
+              echo "ERROR: device migration requires manual dev v2 release/0.13.13 dispatch" >&2; exit 1;
             }
             UPDATE_CHANNEL="$RELEASE_CHANNEL" python3 -c 'import os,sys; sys.path.insert(0,"build/ci"); from device_baseline import parse; parse(os.environ["DEVICE_BASELINE_JSON"], os.environ["UPDATE_CHANNEL"])'
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## radar-puffin-v0.13.13 (UNRELEASED)
+
+See [the 0.13.13 release note](release/radar-puffin-v0.13.13.md).
+
 ## radar-puffin-v0.13.12 (UNRELEASED)
 
 See [the 0.13.12 release note](release/radar-puffin-v0.13.12.md).

--- a/build/ci/DEV-DEVICE-MIGRATION.md
+++ b/build/ci/DEV-DEVICE-MIGRATION.md
@@ -6,7 +6,7 @@ payloads can therefore differ from the public baseline and correctly fail a
 preserve check.
 
 For explicitly authorized development migration only, manual Hosted build
-supports `device_baseline_json` on `release/0.13.12`, with `update_channel=dev`
+supports `device_baseline_json` on `release/0.13.13`, with `update_channel=dev`
 and `ota_format=v2`. Other combinations fail before build. Leaving the input
 empty retains the release-derived baseline and v1 defaults unchanged.
 

--- a/build/ci/ota_v2_inputs.py
+++ b/build/ci/ota_v2_inputs.py
@@ -8,8 +8,8 @@ import re
 from pathlib import Path
 from urllib.parse import urlsplit
 
-EXPECTED_RELEASE = "0.13.12"
-EXPECTED_BASE_RELEASE = "radar-puffin-v0.13.11"
+EXPECTED_RELEASE = "0.13.13"
+EXPECTED_BASE_RELEASE = "radar-puffin-v0.13.12"
 HEX64 = re.compile(r"[0-9a-f]{64}\Z")
 BASE_URL_PREFIX = (
     "https://github.com/aslater3/LibreEcho/releases/download/"

--- a/build/ci/sign_ota_candidate.py
+++ b/build/ci/sign_ota_candidate.py
@@ -18,7 +18,7 @@ from ota_v2_product import (
 )
 
 SCHEMA = "libreecho-ota-v2-signing-handoff-v1"
-EXPECTED_RELEASE = "0.13.12"
+EXPECTED_RELEASE = "0.13.13"
 FEATURES = ("airplay2", "tts", "wakeword", "stt", "assistant")
 HEX64 = set("0123456789abcdef")
 

--- a/build/tests/test_device_baseline.py
+++ b/build/tests/test_device_baseline.py
@@ -44,7 +44,7 @@ class DeviceBaselineTests(unittest.TestCase):
         guard = textwrap.dedent(block.split('          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then', 1)[0])
         env = dict(os.environ, DEVICE_BASELINE_JSON=json.dumps(self.baseline()),
                    GITHUB_EVENT_NAME='workflow_dispatch', RELEASE_CHANNEL='dev',
-                   OTA_FORMAT_INPUT='v2', GITHUB_REF='refs/heads/release/0.13.12')
+                   OTA_FORMAT_INPUT='v2', GITHUB_REF='refs/heads/release/0.13.13')
         self.assertEqual(subprocess.run(['bash', '-c', guard], env=env, cwd=root, capture_output=True, timeout=10).returncode, 0)
         for key, value in [('RELEASE_CHANNEL', 'stable'), ('OTA_FORMAT_INPUT', 'v1'),
                            ('GITHUB_EVENT_NAME', 'push'), ('GITHUB_REF', 'refs/heads/main'),
@@ -82,7 +82,7 @@ class DeviceBaselineTests(unittest.TestCase):
             base.write_text(json.dumps(baseline))
             output, assets = root / 'plan.json', root / 'ota-assets'
             args = ['--base-catalog', str(base), '--candidate-catalog', str(candidate),
-                    '--release', '0.13.12', '--source-commit', COMMIT,
+                    '--release', '0.13.13', '--source-commit', COMMIT,
                     '--output', str(output), '--asset-output-dir', str(assets)]
             rejected = run_plan(*args, '--update-channel', 'stable')
             self.assertNotEqual(rejected.returncode, 0)
@@ -120,7 +120,7 @@ class DeviceBaselineTests(unittest.TestCase):
             base.write_text(json.dumps(self.baseline()))
             output = root / 'plan.json'
             args = ['--base-catalog', str(base), '--candidate-catalog', str(candidate),
-                    '--release', '0.13.12', '--source-commit', COMMIT, '--output', str(output)]
+                    '--release', '0.13.13', '--source-commit', COMMIT, '--output', str(output)]
             rejected = run_plan(*args)
             self.assertNotEqual(rejected.returncode, 0)
             self.assertFalse(output.exists())

--- a/build/tests/test_ota_v2_complete_gate.py
+++ b/build/tests/test_ota_v2_complete_gate.py
@@ -36,7 +36,7 @@ def sha256(data: bytes) -> str:
 
 
 def contract(root: Path) -> tuple[dict[str, object], dict[str, object], Path, Path, SigningKey]:
-    release = "0.13.12"
+    release = "0.13.13"
     source = "4" * 40
     asset_dir = root / "ota-assets"
     asset_dir.mkdir()
@@ -126,7 +126,7 @@ class CompleteControlGateTests(unittest.TestCase):
         write_control(bundle, raw, key, boot)
         with self.assertRaises(ContractError):
             validate_control_tar(
-                bundle, root / "public.hex", "v2", "0.13.12",
+                bundle, root / "public.hex", "v2", "0.13.13",
                 feature_plan=plan, feature_inventory=inventory, feature_asset_dir=asset_dir,
                 expected_channel="stable", boot_path=boot,
                 expected_key_sha256=sha256((root / "public.hex").read_bytes()),

--- a/build/tests/test_ota_v2_signing.py
+++ b/build/tests/test_ota_v2_signing.py
@@ -51,23 +51,23 @@ class OtaV2InputTests(unittest.TestCase):
             "ota_base_catalog_sha256": "",
         })
 
-    def test_v2_requires_the_actual_01312_candidate_and_pinned_prior_catalog(self) -> None:
-        with self.assertRaisesRegex(InputError, "0.13.12"):
+    def test_v2_requires_the_actual_01313_candidate_and_pinned_prior_catalog(self) -> None:
+        with self.assertRaisesRegex(InputError, "0.13.13"):
             validate_inputs(
                 "v2", "0.14.0",
-                "https://github.com/aslater3/LibreEcho/releases/download/radar-puffin-v0.13.11/libreecho-radar-puffin-v0.13.11-feature-catalog.json",
-                "a" * 64, "workflow_dispatch", "refs/heads/release/0.13.12",
+                "https://github.com/aslater3/LibreEcho/releases/download/radar-puffin-v0.13.12/libreecho-radar-puffin-v0.13.12-feature-catalog.json",
+                "a" * 64, "workflow_dispatch", "refs/heads/release/0.13.13",
             )
         with self.assertRaises(InputError):
             validate_inputs(
-                "v2", "0.13.12",
+                "v2", "0.13.13",
                 "https://attacker.invalid/$(touch-pwned).json", "a" * 64,
-                "workflow_dispatch", "refs/heads/release/0.13.12",
+                "workflow_dispatch", "refs/heads/release/0.13.13",
             )
         accepted = validate_inputs(
-            "v2", "0.13.12",
-            "https://github.com/aslater3/LibreEcho/releases/download/radar-puffin-v0.13.11/libreecho-radar-puffin-v0.13.11-feature-catalog.json",
-            "a" * 64, "workflow_dispatch", "refs/heads/release/0.13.12",
+            "v2", "0.13.13",
+            "https://github.com/aslater3/LibreEcho/releases/download/radar-puffin-v0.13.12/libreecho-radar-puffin-v0.13.12-feature-catalog.json",
+            "a" * 64, "workflow_dispatch", "refs/heads/release/0.13.13",
         )
         self.assertEqual(accepted["ota_format"], "v2")
 
@@ -82,14 +82,14 @@ class OtaV2InputTests(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="ota-v2-publisher-gate-") as directory:
             output = Path(directory)
             expected = [
-                {"name": "libreecho-radar-puffin-0.13.12-assistant.runtime.squashfs"},
-                {"name": "libreecho-radar-puffin-0.13.12-assistant.runtime-manifest.json"},
+                {"name": "libreecho-radar-puffin-0.13.13-assistant.runtime.squashfs"},
+                {"name": "libreecho-radar-puffin-0.13.13-assistant.runtime-manifest.json"},
             ]
             for item in expected:
                 (output / item["name"]).write_bytes(b"fixture")
-            (output / "libreecho-radar-puffin-0.13.12-extra.payload.squashfs").write_bytes(b"extra")
+            (output / "libreecho-radar-puffin-0.13.13-extra.payload.squashfs").write_bytes(b"extra")
             with self.assertRaisesRegex(ContractError, "publisher asset set"):
-                validate_v2_publisher_asset_set(output, "0.13.12", expected)
+                validate_v2_publisher_asset_set(output, "0.13.13", expected)
 
 
 class OtaV2SigningHandoffTests(unittest.TestCase):
@@ -147,7 +147,7 @@ class OtaV2SigningHandoffTests(unittest.TestCase):
                 return {"name": name, "path": str(asset), "size": asset.stat().st_size, "sha256": hashlib.sha256(asset.read_bytes()).hexdigest()}
             data = {
                 "schema": "libreecho-ota-v2-signing-handoff-v1", "format": "v2",
-                "release": "0.13.12", "source_commit": "a" * 40,
+                "release": "0.13.13", "source_commit": "a" * 40,
                 "update_channel": "stable", "base_catalog_sha256": hashlib.sha256(asset.read_bytes()).hexdigest(),
                 "run_dir": str(root), "base_catalog": record(asset.name),
                 "build_manifest": record(asset.name),
@@ -157,7 +157,7 @@ class OtaV2SigningHandoffTests(unittest.TestCase):
             }
             handoff.write_text(json.dumps(data), encoding="utf-8")
             with self.assertRaisesRegex(HandoffError, "schema mismatch"):
-                validate_handoff(handoff, "0.13.12")
+                validate_handoff(handoff, "0.13.13")
 
     def test_actual_platform_v1_bundle_is_verified_by_product_with_ephemeral_key(self) -> None:
         from nacl.signing import SigningKey
@@ -219,7 +219,7 @@ class OtaV2SigningHandoffTests(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="ota-v2-signer-fixture-") as directory:
             root = Path(directory)
             run, commits = fixture(root)
-            add_v2_contract(run, commits, release="0.13.12")
+            add_v2_contract(run, commits, release="0.13.13")
             build_manifest = json.loads((run / "manifest.json").read_text())
             build_manifest["update_channel"] = "stable"
             (run / "manifest.json").write_text(json.dumps(build_manifest))
@@ -235,7 +235,7 @@ class OtaV2SigningHandoffTests(unittest.TestCase):
             anchor = hashlib.sha256(public_path.read_bytes()).hexdigest()
             with mock.patch.dict(os.environ, {"LIBREECHO_OTA_EXPECTED_PUBLIC_KEY_SHA256": anchor}):
                 create_handoff(
-                    run, "0.13.12", commits["ui"], "stable", base,
+                    run, "0.13.13", commits["ui"], "stable", base,
                     hashlib.sha256(base.read_bytes()).hexdigest(), handoff,
                     PLATFORM_ROOT, PLATFORM_TOOL,
                 )
@@ -265,7 +265,7 @@ class OtaV2SigningHandoffTests(unittest.TestCase):
                 command = invoke_platform_signer(
                     platform_tool=root / "make_ota_bundle.py", boot_image=boot,
                     build_manifest=manifest, signing_key=key, public_key=public,
-                    output=output, plan=plan, release="0.13.12",
+                    output=output, plan=plan, release="0.13.13",
                     update_channel="stable",
                 )
                 self.assertIn("--format", command)

--- a/build/tests/test_plan_feature_transaction.py
+++ b/build/tests/test_plan_feature_transaction.py
@@ -96,7 +96,7 @@ class FeaturePlanTests(unittest.TestCase):
         return [
             "--base-catalog", str(base),
             "--candidate-catalog", str(candidate),
-            "--release", "0.13.12",
+            "--release", "0.13.13",
             "--source-commit", COMMIT,
             "--output", str(output),
             "--inventory-output", str(inventory),
@@ -113,14 +113,14 @@ class FeaturePlanTests(unittest.TestCase):
             plan = json.loads(output.read_text())
             self.assertEqual([record["feature_id"] for record in plan["features"]], list(FEATURES))
             self.assertEqual(plan["features"][4]["action"], "replace")
-            self.assertEqual(plan["features"][4]["asset"], "libreecho-radar-puffin-0.13.12-assistant.payload.squashfs")
+            self.assertEqual(plan["features"][4]["asset"], "libreecho-radar-puffin-0.13.13-assistant.payload.squashfs")
             self.assertEqual(plan["features"][1]["action"], "preserve")
             self.assertNotIn("path", plan["features"][4])
             inventory_data = json.loads(inventory.read_text())
             self.assertEqual(inventory_data["transaction_type"], "system")
             self.assertEqual([asset["name"] for asset in inventory_data["assets"]], [
-                "libreecho-radar-puffin-0.13.12-assistant.manifest.json",
-                "libreecho-radar-puffin-0.13.12-assistant.payload.squashfs",
+                "libreecho-radar-puffin-0.13.13-assistant.manifest.json",
+                "libreecho-radar-puffin-0.13.13-assistant.payload.squashfs",
             ])
 
     def test_runtime_is_selected_only_for_a_compatible_capsule_pair(self) -> None:
@@ -150,7 +150,7 @@ class FeaturePlanTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             record = json.loads(output.read_text())["features"][4]
             self.assertEqual(record["action"], "runtime")
-            self.assertEqual(record["asset"], "libreecho-radar-puffin-0.13.12-assistant.runtime.squashfs")
+            self.assertEqual(record["asset"], "libreecho-radar-puffin-0.13.13-assistant.runtime.squashfs")
             self.assertTrue((root / "assets" / record["asset"]).is_file())
 
     def test_real_platform_capsule_producer_and_product_consumer_verify_semantics(self) -> None:
@@ -166,8 +166,8 @@ class FeaturePlanTests(unittest.TestCase):
                 sys.executable, str(PLATFORM / "feature_runtime/package_runtime.py"),
                 "--feature-id", "assistant", "--base-payload", str(base_root / "assistant.squashfs"),
                 "--base-manifest", str(base_root / "assistant.manifest.json"),
-                "--product-release", "0.13.12", "--source-commit", COMMIT,
-                "--component", "libreecho-agentd", "--component-version", "0.13.12",
+                "--product-release", "0.13.13", "--source-commit", COMMIT,
+                "--component", "libreecho-agentd", "--component-version", "0.13.13",
                 "--build-identity", "fixture-build", "--service-dependency", "libreecho-runtime-base",
                 "--compatibility", json.dumps({"abi": "arm32-linux-gnueabihf-v1", "model": "mt8163-radar-puffin", "mounts": ["/usr/local/sbin"], "dependencies": ["libreecho-runtime-base"]}, sort_keys=True),
                 "--replacement", f"usr/local/sbin/libreecho-agentd={source}", "--max-bytes", "1048576",
@@ -196,8 +196,8 @@ class FeaturePlanTests(unittest.TestCase):
                 sys.executable, str(PLATFORM / "feature_runtime/package_runtime.py"),
                 "--feature-id", "assistant", "--base-payload", str(base_root / "assistant.squashfs"),
                 "--base-manifest", str(base_root / "assistant.manifest.json"),
-                "--product-release", "0.13.12", "--source-commit", COMMIT,
-                "--component", "libreecho-agentd", "--component-version", "0.13.12",
+                "--product-release", "0.13.13", "--source-commit", COMMIT,
+                "--component", "libreecho-agentd", "--component-version", "0.13.13",
                 "--build-identity", "fixture-build", "--service-dependency", "libreecho-runtime-base",
                 "--compatibility", json.dumps({"abi": "arm32-linux-gnueabihf-v1", "model": "mt8163-radar-puffin", "mounts": ["/usr/local/sbin"], "dependencies": ["libreecho-runtime-base"]}, sort_keys=True),
                 "--replacement", f"usr/local/sbin/libreecho-agentd={source}", "--max-bytes", "1048576",

--- a/build/tests/test_prepare_dev_release.py
+++ b/build/tests/test_prepare_dev_release.py
@@ -111,7 +111,7 @@ def make_signed_ota(run: Path, output: Path, version: str = "fixture-v1", ota_fo
         raise RuntimeError(result.stderr)
 
 
-def add_v2_contract(run: Path, commits: dict[str, str], release: str = "0.13.12", *, action: str = "runtime") -> dict[str, str]:
+def add_v2_contract(run: Path, commits: dict[str, str], release: str = "0.13.13", *, action: str = "runtime") -> dict[str, str]:
     asset_dir = run / "ota-assets"
     asset_dir.mkdir()
     payload_suffix = "runtime.squashfs" if action == "runtime" else "payload.squashfs"
@@ -194,7 +194,7 @@ class Tests(unittest.TestCase):
             run, commits = fixture(root)
             names = add_v2_contract(run, commits, action="replace")
             ota = run / "development.ota.tar"
-            make_signed_ota(run, ota, "0.13.12", "v2", run / "feature-plan.json")
+            make_signed_ota(run, ota, "0.13.13", "v2", run / "feature-plan.json")
             candidate = run / "CURRENT.candidate"
             text = candidate.read_text().replace("ota_signing_mode=github\n", "ota_signing_mode=local\n")
             text = text.replace("ota_bundle=\n", "ota_bundle=" + str(ota) + "\n")
@@ -217,14 +217,14 @@ class Tests(unittest.TestCase):
     def test_v2_asset_namespace_rejects_missing_extra_and_unsafe_members(self):
         sys.path.insert(0, str(ROOT / "build/ci"))
         from ota_v2_product import ContractError, validate_v2_publisher_asset_set
-        prefix = "libreecho-radar-puffin-0.13.12-"
+        prefix = "libreecho-radar-puffin-0.13.13-"
         names = [prefix + "wakeword.payload.squashfs", prefix + "wakeword.manifest.json"]
         for mutation in ("valid", "missing-manifest", "extra-manifest", "extra-file", "symlink", "directory"):
             with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as temporary:
                 out = Path(temporary)
                 for name in names:
                     (out/name).write_bytes(b"fixture")
-                (out/"libreecho-radar-puffin-v0.13.12-build.json").write_text("{}")
+                (out/"libreecho-radar-puffin-v0.13.13-build.json").write_text("{}")
                 if mutation == "missing-manifest":
                     (out/names[1]).unlink()
                 elif mutation == "extra-manifest":
@@ -236,10 +236,10 @@ class Tests(unittest.TestCase):
                 elif mutation == "directory":
                     (out/(prefix+"extra.manifest.json")).mkdir()
                 if mutation == "valid":
-                    validate_v2_publisher_asset_set(out, "0.13.12", [{"name": name} for name in names])
+                    validate_v2_publisher_asset_set(out, "0.13.13", [{"name": name} for name in names])
                 else:
                     with self.assertRaises(ContractError):
-                        validate_v2_publisher_asset_set(out, "0.13.12", [{"name": name} for name in names])
+                        validate_v2_publisher_asset_set(out, "0.13.13", [{"name": name} for name in names])
 
     def test_signed_all_preserve_publication_without_empty_asset_directory(self):
         import shutil
@@ -260,7 +260,7 @@ class Tests(unittest.TestCase):
                 inventory['assets'] = []
                 inventory_path.write_text(json.dumps(inventory))
                 ota = run / 'development.ota.tar'
-                make_signed_ota(run, ota, '0.13.12', 'v2', plan_path)
+                make_signed_ota(run, ota, '0.13.13', 'v2', plan_path)
                 candidate = run / 'CURRENT.candidate'
                 text = candidate.read_text().replace('ota_signing_mode=github\n', 'ota_signing_mode=local\n')
                 text = text.replace('ota_bundle=\n', 'ota_bundle=' + str(ota) + '\n')
@@ -287,7 +287,7 @@ class Tests(unittest.TestCase):
             run, commits = fixture(root)
             names = add_v2_contract(run, commits)
             ota = run / "development.ota.tar"
-            make_signed_ota(run, ota, "0.13.12", "v2", run / "feature-plan.json")
+            make_signed_ota(run, ota, "0.13.13", "v2", run / "feature-plan.json")
             candidate = run / "CURRENT.candidate"
             text = candidate.read_text().replace("ota_signing_mode=github\n", "ota_signing_mode=local\n")
             text = text.replace("ota_bundle=\n", "ota_bundle=" + str(ota) + "\n")

--- a/build/tests/test_release_route.py
+++ b/build/tests/test_release_route.py
@@ -7,10 +7,10 @@ class ReleaseRouteTests(unittest.TestCase):
         return dict(schema='libreecho-release-request-v1', channel=channel, version='', release_tag='', release_notes='')
 
     def test_manual_release_dev_is_not_stable(self):
-        self.assertEqual(route(self.request(), 'release/0.13.12', 'workflow_dispatch'), 'dev')
+        self.assertEqual(route(self.request(), 'release/0.13.13', 'workflow_dispatch'), 'dev')
 
     def test_release_push_is_validation_only(self):
-        self.assertEqual(route(self.request(), 'release/0.13.12', 'push'), 'none')
+        self.assertEqual(route(self.request(), 'release/0.13.13', 'push'), 'none')
 
     def test_main_dev_events(self):
         for event in ('push', 'schedule', 'workflow_dispatch'):
@@ -19,15 +19,15 @@ class ReleaseRouteTests(unittest.TestCase):
     def test_stable_retains_required_fields(self):
         request = self.request('stable')
         with self.assertRaises(ValueError):
-            route(request, 'release/0.13.12', 'workflow_dispatch')
-        request.update(version='0.13.12', release_tag='radar-puffin-v0.13.12', release_notes='release/notes.md', amonet_repository='reviewed', amonet_tag='reviewed', amonet_commit='a'*40, ssh_enabled='0')
-        self.assertEqual(route(request, 'release/0.13.12', 'workflow_dispatch'), 'stable')
-        for branch, event in [('main','workflow_dispatch'),('release/0.13.12','push'),('release/0.13.11','workflow_dispatch')]:
+            route(request, 'release/0.13.13', 'workflow_dispatch')
+        request.update(version='0.13.13', release_tag='radar-puffin-v0.13.13', release_notes='release/notes.md', amonet_repository='reviewed', amonet_tag='reviewed', amonet_commit='a'*40, ssh_enabled='0')
+        self.assertEqual(route(request, 'release/0.13.13', 'workflow_dispatch'), 'stable')
+        for branch, event in [('main','workflow_dispatch'),('release/0.13.13','push'),('release/0.13.12','workflow_dispatch')]:
             with self.assertRaises(ValueError):
                 route(request, branch, event)
 
     def test_invalid_request_rejected(self):
-        for request in (None, {}, self.request('unknown'), self.request() | {'version':'0.13.12'}):
+        for request in (None, {}, self.request('unknown'), self.request() | {'version':'0.13.13'}):
             with self.assertRaises(ValueError):
                 route(request, 'main', 'push')
 

--- a/release/radar-puffin-v0.13.13.md
+++ b/release/radar-puffin-v0.13.13.md
@@ -1,0 +1,51 @@
+# LibreEcho radar-puffin v0.13.13
+
+LibreEcho 0.13.13 is a focused OTA v2 maintenance release for the Amazon Echo
+2nd Gen (`radar_puffin`, ARMv7, Linux 6.1), based on the coordinated 0.13.12
+source set. It preserves the network OTA path and does not add or alter the
+initial installer.
+
+## OTA v2 maintenance
+
+- Advance the protected Product signing handoff and candidate contract to
+  0.13.13.
+- Pin the v2 input contract to the published 0.13.12 feature catalog as the
+  preceding stable baseline, while retaining checksum verification and the
+  device signature trust boundary.
+- Move the explicit development-device migration guard to
+  `release/0.13.13`; other channels, events, and branches remain rejected.
+- Keep signer provenance bound to the v2 candidate, trusted OTA public-key
+  digest, measured source/tool/dependency identities, and complete feature
+  asset inventory.
+
+## Source and validation policy
+
+- Product release ID: `radar-puffin-v0.13.13`
+- Product version: `0.13.13`
+- Release impact: `patch`
+- Baseline: coordinated 0.13.12 source set; no unrelated development changes.
+- Product, Platform, Linux, and UI use coordinated `release/0.13.13` refs. The
+  hosted build must record their exact commits in the candidate manifest and
+  `release-source-commits.txt`; UI `VERSION` must equal `0.13.13`.
+
+Merging source is not publication or proof of hardware behavior. Publication
+requires component checks, the canonical hosted Product build, independent
+image/provenance verification, and separately authorized OTA signature,
+inactive-slot readback, boot, rollback, and service-readiness acceptance.
+
+## Installation and verification
+
+Use only assets attached to the matching published Product release and verify
+them against its `SHA256SUMS`. A branch name or source note alone is not an
+installable artifact or authorization to install, reboot, or publish. This
+release does not change the initial-install path.
+
+## License and distribution boundary
+
+Distribution remains subject to the public component allowlist and individual
+component notices. The community-noncommercial wakeword payload retains its
+**CC-BY-NC-SA-4.0** noncommercial, attribution, modification-notice, and
+ShareAlike requirements. TTS voice assets retain their separate
+**CC-BY-SA-4.0** obligations. Credentials, signing material, device
+identifiers, owner-local connectivity firmware, and private build metadata are
+excluded from public release metadata.


### PR DESCRIPTION
## Summary / root cause

Product 0.13.13 was cut from the verified Product `release/0.13.12` source at `8ab4762657e327fe74d4100a4cf9134db4a78b93`, but the Product OTA v2 signer/input contracts and development-device migration guard still named 0.13.12. This advances the narrow release pins to 0.13.13 and uses the published 0.13.12 feature catalog as the prior baseline.

## Changed files

- `.github/workflows/build-release.yml`: move the explicit device migration guard to `release/0.13.13`.
- `build/ci/ota_v2_inputs.py`: pin the candidate to 0.13.13 and the prior catalog to `radar-puffin-v0.13.12`.
- `build/ci/sign_ota_candidate.py`: bind the protected signer to 0.13.13.
- `build/ci/DEV-DEVICE-MIGRATION.md`: align the documented migration guard.
- OTA v2 and release-route tests: update candidate, asset, branch, and prior-baseline fixtures to 0.13.13.
- `release/radar-puffin-v0.13.13.md` and `CHANGELOG.md`: add the authored 0.13.13 release note/index.

No initial-installer, device, image, or publication implementation changes are included.

## Coordination

Relates to #150.

## Tests and evidence

PASS:

- `PYTHONDONTWRITEBYTECODE=1 python -B -m unittest -v build.tests.test_device_baseline build.tests.test_ota_v2_signing.OtaV2InputTests build.tests.test_ota_v2_complete_gate.CompleteControlGateTests build.tests.test_plan_feature_transaction build.tests.test_release_route build.tests.test_fetch_ota_base tools.test_build_release_workflow` — 42 tests passed.
- Python compilation for all changed Python files.
- PyYAML parse of `.github/workflows/build-release.yml`.
- `git diff --check`.

A broader local six-module run reached 47 tests but was blocked by the available local Platform checkout: its `make_ota_bundle.py` lacks the expected `--format` contract and `feature_manifest.py` dependency. This is an existing cross-repository checkout mismatch, not changed by this PR; the focused Product contract suites above pass.

Validation class: host/source only. This does not prove hosted image CI, release publication, network OTA acceptance, or physical hardware behavior.

## Release metadata

- Release impact: patch
- Release note: Advance Product 0.13.13 OTA v2 signer/input provenance and the guarded development migration path from the 0.13.12 baseline.
- Target: `release/0.13.13`
