### PR TITLE
docs(release): record unknown firmware setup acceptance

### DIFF
--- a/release/radar-puffin-v0.13.15.md
+++ b/release/radar-puffin-v0.13.15.md
@@ -17,6 +17,12 @@ set. It contains two functional fixes only and does not incorporate the separate
   persist only the exact SHA-256/size manifest locally with mode `0600`; vendor
   firmware bytes remain on the owner's stock partition and are not persisted or
   redistributed by LibreEcho.
+- During first-run setup, distinguish a complete, structurally compatible but
+  previously unknown owner-local revision from an ordinary import failure and
+  offer an explicit `Accept device firmware` action. Acceptance schedules the
+  existing one-boot validation/enrolment path; malformed, incomplete, unsafe,
+  or changed enrolled sets are not offered for acceptance and continue to fail
+  closed.
 - Require the exact enrolled manifest on later boots and fail closed if the
   enrolled set changes.
 - Report a real no-approved-revision result when safe regular files are present,


### PR DESCRIPTION
## Summary

Update the coordinated Radar/Puffin 0.13.15 release note after the Platform/UI follow-up that exposes safe owner-local acceptance for a previously unknown MT8163 firmware revision during first-run setup.

The release remains a two-fix compatibility hotfix. This does not add a third feature or broaden 0.13.15 scope; it documents the user-facing path for the existing vendor-firmware compatibility fix:

- Platform classifies only a complete, structurally compatible unknown four-file set as `VENDOR_IMPORT_UNKNOWN_COMPATIBLE_SET`;
- setup offers `Accept device firmware` only for that state;
- acceptance schedules the existing one-boot validation/enrolment path;
- malformed, incomplete, unsafe, or changed enrolled sets remain fail-closed;
- only hashes/sizes are persisted locally; vendor payload bytes stay owner-local.

Companion component merges:
- aslater3/LibreEcho-Platform#134
- aslater3/LibreEcho-UI#227

No feature payload, kernel, installer, signing, or release-route code changes are included in this Product PR.