### PR TITLE
docs(release): record the Wyoming satellite metadata fix in the 0.13.15 note

### DIFF
--- a/release/radar-puffin-v0.13.15.md
+++ b/release/radar-puffin-v0.13.15.md
@@ -2,8 +2,8 @@
 
 LibreEcho 0.13.15 is a focused compatibility hotfix for the Amazon Echo 2nd
 Gen (`radar_puffin`, ARMv7, Linux 6.1), based on the coordinated 0.13.14 source
-set. It contains two functional fixes only and does not incorporate the separate
-0.14.0 workstream or change feature payloads.
+set. It contains three functional fixes only and does not incorporate the
+separate 0.14.0 workstream or change feature payloads.
 
 ## MT8163 owner-local connectivity firmware compatibility
 
@@ -39,6 +39,14 @@ set. It contains two functional fixes only and does not incorporate the separate
   equals the factory IDME value across warm and cold reboots and that DHCP
   identity remains stable.
 
+## Home Assistant Wyoming satellite metadata
+
+- Include the `attribution` and `installed` metadata that Home Assistant's
+  Wyoming client requires on the satellite, microphone, and speaker entries of
+  the `describe`/`info` exchange. Home Assistant rejects the whole info event
+  when either field is missing, so adding the device through the Wyoming
+  integration failed with an unknown error and created no config entry.
+
 ## OTA v2 maintenance
 
 - Advance the protected Product signing handoff and candidate contract to
@@ -62,8 +70,9 @@ Source merges and host checks do not establish physical hardware acceptance.
 Publication requires reviewed component changes, exact-head checks, the
 canonical hosted Product build, independent image/provenance verification, and
 complete signed asset validation. For this hotfix, hardware validation must also
-cover both supported hash-pinned stock firmware revisions and stable IDME-backed
-Wi-Fi identity across reboots before publication.
+cover both supported hash-pinned stock firmware revisions, stable IDME-backed
+Wi-Fi identity across reboots, and a Home Assistant Wyoming integration setup
+that adds the satellite and creates its config entry, before publication.
 
 ## Installation and verification
 


### PR DESCRIPTION
## Summary

Include the Wyoming satellite metadata fix (aslater3/LibreEcho-UI#228, companion PR aslater3/LibreEcho-UI#230) in the coordinated `radar-puffin-v0.13.15` hotfix and record it in the release note as a third functional fix.

Root cause recorded in the UI companion: `wyomingd`'s `describe`/`info` payload omitted the `attribution`/`installed` artifact metadata Home Assistant's Wyoming client requires, so the integration refused the whole info event and could not add the device.

## Changed files

- `release/radar-puffin-v0.13.15.md` — new "Home Assistant Wyoming satellite metadata" section; scope sentence updated (two -> three functional fixes); the pre-publication hardware-validation requirement now includes a Home Assistant Wyoming setup that adds the satellite.

## Testing and evidence (host)

- `python3 tools/check-public-metadata.py` — `public_metadata_gate=cleared root=release`
- `python -B -m unittest tools.test_release_tools` — 36 tests OK
- `Public release gate` (`release-metadata` job) — PASS: https://github.com/aslater3/LibreEcho/actions/runs/34508265127
- Documentation/metadata only; no build, image, deployment, or hardware evidence claimed. The existing hosted candidate (`libreecho-0.13.15-1cbd6ad`) predates this and the UI fix and must be rebuilt from the final release heads before publication.

## Release impact: patch

## Release note: none — this PR only updates the 0.13.15 release note text (the included UI fix carries its own user-facing note).

Linked issue: aslater3/LibreEcho-UI#228 (references; the release is unpublished and hardware acceptance remains)
