### PR TITLE
chore: default release dispatches to OTA v2 and derive the candidate version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -46,9 +46,9 @@ on:
         default: dfefe52f0eed7296012707cfff1f753b0ea33257
         type: string
       ota_format:
-        description: OTA contract; v1 is the retained bridge default
+        description: OTA contract; v2 is the release dispatch default (v1 remains the bridge format)
         required: false
-        default: v1
+        default: v2
         type: choice
         options: [v1, v2]
       device_baseline_json:
@@ -160,6 +160,15 @@ jobs:
               ;;
             *) echo "ERROR: unsupported release channel: $RELEASE_CHANNEL" >&2; exit 1 ;;
           esac
+          # A release dispatch that does not name an OTA v2 candidate uses the
+          # branch version.  Non-dispatch builds still enter with the v1
+          # bridge literal and never reach this branch.
+          if [[ "$OTA_FORMAT_INPUT" == v2 && -z "$OTA_RELEASE_INPUT" ]]; then
+            case "$GITHUB_REF" in
+              refs/heads/release/*) OTA_RELEASE_INPUT="${GITHUB_REF_NAME#release/}" ;;
+              *) echo "ERROR: OTA v2 requires a release/X.Y.Z ref (got $GITHUB_REF); select v1 for main builds" >&2; exit 1 ;;
+            esac
+          fi
           python3 build/ci/ota_v2_inputs.py \
             --format "$OTA_FORMAT_INPUT" --release "$OTA_RELEASE_INPUT" \
             --base-catalog-url "$OTA_BASE_CATALOG_URL_INPUT" \

--- a/build/build.sh
+++ b/build/build.sh
@@ -137,8 +137,10 @@ PLATFORM_RUNTIME_VERIFIER="$TOOLS_DIR/feature_runtime/verify_runtime.py"
 OTA_PUBLIC_KEY="$OTA_DIR/ota-public-key.hex"
 OTA_SIGNING_KEY="${LIBREECHO_OTA_SIGNING_KEY:-$PRIVATE_ROOT/ota-signing-key.hex}"
 OTA_SIGNING_MODE="${LIBREECHO_OTA_SIGNING_MODE:-github}"
-# v1 remains the bridge default.  v2 is opt-in and requires the exact prior
-# release catalog; no Product-side compatibility fields are invented here.
+# The release workflow dispatches default to v2 and always pass the format
+# explicitly; v1 remains the fallback for local builds that do not name one.
+# v2 requires the exact prior release catalog; no Product-side compatibility
+# fields are invented here.
 OTA_FORMAT="${LIBREECHO_OTA_FORMAT:-v1}"
 OTA_RELEASE="${LIBREECHO_OTA_RELEASE:-}"
 OTA_BASE_CATALOG="${LIBREECHO_OTA_BASE_CATALOG:-}"

--- a/tools/test_build_release_workflow.py
+++ b/tools/test_build_release_workflow.py
@@ -405,6 +405,17 @@ class Tests(unittest.TestCase):
   self.assertIn('IFS= read -r release_notes_title <"$RELEASE_NOTES"', W)
   self.assertNotIn('checked-in release-notes file is required', (ROOT/'build/README.md').read_text())
 
+ def test_ota_v2_dispatch_default(self):
+  # v2 is the release dispatch default; the v1 bridge remains only the
+  # non-dispatch fallback literal.  A dispatch that does not name a
+  # candidate derives it from the release branch; main builds must select
+  # v1 explicitly.
+  self.assertIn('description: OTA contract; v2 is the release dispatch default', W)
+  self.assertIn('default: v2', W)
+  self.assertIn("OTA_FORMAT_INPUT: ${{ inputs.ota_format || 'v1' }}", W)
+  self.assertIn('OTA_RELEASE_INPUT="${GITHUB_REF_NAME#release/}"', W)
+  self.assertIn('select v1 for main builds', W)
+
  def test_nightly_release_tag_is_accepted(self):
   installer = (ROOT/'tools/libreecho-install.py').read_text()
   self.assertIn('(?:nightly|build)-[0-9a-f-]+', installer)


### PR DESCRIPTION
## Summary

Pin OTA v2 as the default for release dispatches and derive the candidate release from the branch when it is not named. Every stable dispatch since 0.13.11 used `ota_format=v2`; the workflow input still preselected v1, so a dispatch that did not override the input could build a v1 bridge candidate for a v2 release line. v1 candidates cannot complete on devices already carrying v2 authority (the boot gate requires the installed record to be schema 2), which was observed on hardware during 0.13.15 dev validation. v1 remains available and remains the format for non-dispatch builds.

### Changes

- `.github/workflows/build-release.yml`
  - `ota_format` default v1 → v2 (description updated).
  - Resolve step: a `v2` dispatch with no `ota_release` derives the candidate from the release branch (`release/X.Y.Z` → `X.Y.Z`); a `v2` dispatch from a non-release ref fails with an explicit message. Push/scheduled builds still enter with the `v1` bridge literal and are unaffected.
- `build/build.sh` — comment updated; the v1 fallback remains for local builds that do not name a format.
- `tools/test_build_release_workflow.py` — new `test_ota_v2_dispatch_default` asserts the default, the non-dispatch v1 literal, the branch derivation, and the main-build error.

## Testing and evidence

Host (this PR head):
- Derivation simulation: release dispatch with empty release → derived; main dispatch with empty release → explicit error; stable dispatch → prefilled from `release_version`; explicit v1 → untouched; push/main → v1 literal (branch not entered).
- `python3 -B tools/test_build_release_workflow.py` — 13 tests ran, the new test passes. One pre-existing failure (`test_stable_publisher_installs_reviewed_verifier_closure`) reproduces identically on the unmodified tree (local wheelhouse install gap; the CI job installs from the reviewed wheelhouse first).
- `python3 -B -m unittest build.tests.test_fetch_ota_base build.tests.test_ota_v2_signing` — identical results on baseline and change (env-dependent signer-handoff cases need the resolved platform source); `test_v1_is_the_safe_default_bridge` passes.
- `git diff --check` clean.

CI: the build-release PR lane runs the maintained Product pipeline suites (includes the updated workflow contract test). release-gate does not trigger for these paths (none are in its path list).

Hardware: matches the audited 0.13.15 dev flow — the dev candidate was built with `ota_format=v2` and installed on hardware during validation.

## Release impact: none

## Release note: none

Linked issue: none.
