### PR TITLE
chore: default manual builds to ssh_enabled=enabled

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,7 +24,7 @@ on:
       ssh_enabled:
         description: Include password-authenticated root SSH in the image
         required: true
-        default: disabled
+        default: enabled
         type: choice
         options: [disabled, enabled]
       release_version:

--- a/build/README.md
+++ b/build/README.md
@@ -58,7 +58,8 @@ are deliberately separate:
   no-publish OTA-profile image with the development channel. The run artifact is
   validation evidence only and never publishes a release.
 - **SSH option:** all non-dispatch builds keep SSH disabled. A manual GitHub
-  Actions run may select `ssh_enabled=enabled`; that run requires the protected
+  Actions run defaults to `ssh_enabled=enabled` and may select `disabled`; an
+  enabled run requires the protected
   `LIBREECHO_SSH_ROOT_PASSWORD_HASH` secret and embeds the static ARM32 Dropbear
   server plus `dropbearkey` in the initramfs. The image uses password-only root
   login, does not include public-key authorization or persistent host keys, and

--- a/tools/test_build_release_workflow.py
+++ b/tools/test_build_release_workflow.py
@@ -416,6 +416,15 @@ class Tests(unittest.TestCase):
   self.assertIn('OTA_RELEASE_INPUT="${GITHUB_REF_NAME#release/}"', W)
   self.assertIn('select v1 for main builds', W)
 
+ def test_ssh_enabled_default(self):
+  # Manual dispatches default to including the SSH option; an enabled run is
+  # gated on the protected root password hash materialization, and
+  # non-dispatch builds keep the documented disabled fallback invariant.
+  self.assertIn('description: Include password-authenticated root SSH in the image', W)
+  self.assertIn('default: enabled', W)
+  self.assertIn("SSH_ENABLED_INPUT: ${{ inputs.ssh_enabled || 'disabled' }}", W)
+  self.assertIn("needs.resolve-and-preflight.outputs.ssh_enabled == '1'", W)
+
  def test_nightly_release_tag_is_accepted(self):
   installer = (ROOT/'tools/libreecho-install.py').read_text()
   self.assertIn('(?:nightly|build)-[0-9a-f-]+', installer)


### PR DESCRIPTION
Manual dispatches — the stable lane included — now default to including the password-authenticated root SSH option instead of requiring an explicit selection.

- `.github/workflows/build-release.yml`: `ssh_enabled` input default `disabled` -> `enabled`.
- `build/README.md`: SSH option paragraph now states the manual-run default (and that `disabled` remains selectable).
- `tools/test_build_release_workflow.py`: new `test_ssh_enabled_default` pins the default, the non-dispatch `disabled` fallback literal, and the protected-hash gate.

## Behavior notes
- An enabled build is mechanically unchanged: it still requires the protected `LIBREECHO_SSH_ROOT_PASSWORD_HASH` materialization, embeds the static ARM32 Dropbear server plus `dropbearkey`, and records both binary hashes in the release manifest.
- Non-dispatch builds (pushes, nightly schedule, PR validation) keep the documented `disabled` fallback invariant.
- **Security posture:** future manual/stable builds will default to password-authenticated root SSH present in the image; selecting `disabled` remains available. This applies to future builds only — the published `radar-puffin-v0.13.15` artifact is unchanged and is never rewritten. Worth a line in the next release's notes.

## Testing
- `python3 -B tools/test_build_release_workflow.py` -> 14 tests OK (new test included).
- `git diff --check` clean.

## Release impact: none
## Release note: none
Linked issue: none (maintainer request).