### PR TITLE
chore(ci): update checkout and setup-python actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -72,7 +72,7 @@ jobs:
       ssh_enabled: ${{ steps.resolve.outputs.ssh_enabled }}
       signing_mode: ${{ steps.resolve.outputs.signing_mode }}
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with: {fetch-depth: 1, persist-credentials: false}
       - id: resolve
         env:
@@ -174,9 +174,9 @@ jobs:
     name: Product pipeline contract checks
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with: {fetch-depth: 1, persist-credentials: false}
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.11'
       - name: Run maintained Product pipeline suites
@@ -210,7 +210,7 @@ jobs:
     outputs:
       armhf_root_digest: ${{ steps.armhf-pkg.outputs.armhf_root_digest }}
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with: {fetch-depth: 1, persist-credentials: false}
 
       # --- Layer 1: fetched public inputs, keyed by the inventory digest ---
@@ -379,19 +379,19 @@ jobs:
       name: ${{ (needs.resolve-and-preflight.outputs.signing_mode == 'local' || needs.resolve-and-preflight.outputs.ssh_enabled == '1') && (needs.resolve-and-preflight.outputs.channel == 'stable' && 'stable-release' || 'dev-release') || 'dev-build' }}
     permissions: {contents: read}
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ needs.resolve-and-preflight.outputs.product_sha }}
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: aslater3/LibreEcho-Platform
           ref: ${{ needs.resolve-and-preflight.outputs.platform_sha }}
           path: sources/platform
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: aslater3/LibreEcho-Linux-6.1
           ref: ${{ needs.resolve-and-preflight.outputs.linux_sha }}
@@ -404,14 +404,14 @@ jobs:
           epoch="$(git -C sources/linux show -s --format=%ct HEAD)"
           git -C sources/linux ls-files -z |
             (cd sources/linux && xargs -0 touch -h -d "@$epoch" --)
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: aslater3/LibreEcho-UI
           ref: ${{ needs.resolve-and-preflight.outputs.ui_sha }}
           path: sources/ui
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: aslater3/LibreEcho
           ref: ${{ needs.resolve-and-preflight.outputs.product_sha }}
@@ -430,7 +430,7 @@ jobs:
         with:
           name: armhf-root-${{ needs.resolve-and-preflight.outputs.source_set_id }}
           path: ${{ runner.temp }}/armhf-root
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.11'
       - name: Install reviewed OTA signing dependency closure

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       channel: ${{ steps.route.outputs.channel }}
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
@@ -60,7 +60,7 @@ jobs:
       group: publish-hosted-dev-channel
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 1
@@ -88,7 +88,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.artifact.outputs.name }}
           path: verified-build
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.11'
       - name: Install reviewed OTA verification dependencies
@@ -217,7 +217,7 @@ jobs:
       group: stable-release-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 1
@@ -245,7 +245,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.artifact.outputs.name }}
           path: verified-build
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.11'
       - name: Install reviewed OTA verification dependencies

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -53,10 +53,10 @@ jobs:
   release-metadata:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.11'
       - name: Validate metadata JSON


### PR DESCRIPTION
## Summary
- update every `actions/checkout` use in the Product build/release workflows to the pinned v7.0.1 commit
- update every `actions/setup-python` use to the pinned v7 commit
- preserve the existing Python 3.11 runtime, action SHA pinning policy, workflow permissions and release/build logic

This covers `build-release.yml`, `publish-release.yml` and `release-gate.yml` so the Product repo is aligned with the Actions maintenance already being taken in UI, Platform and Linux.

## Verification
- diff is limited to 17 immutable action-revision substitutions across the three workflow files
- existing Product contract checks include enforcement that `uses:` references remain pinned to 40-character SHAs
